### PR TITLE
Improve display of rules

### DIFF
--- a/src/rule_types.jl
+++ b/src/rule_types.jl
@@ -160,6 +160,9 @@ Rule(f) = Rule{Core.Typeof(f),Nothing}(f, nothing)
 
 (rule::Rule{F})(args...) where {F} = Cassette.overdub(RULE_CONTEXT, rule.f, args...)
 
+Base.show(io::IO, rule::Rule{<:Any, Nothing}) = print(io, "Rule($(rule.f))")
+Base.show(io::IO, rule::Rule) = print(io, "Rule($(rule.f), $(rule.u))")
+
 # Specialized accumulation
 # TODO: Does this need to be overdubbed in the rule context?
 accumulate!(Δ, rule::Rule{F,U}, args...) where {F,U<:Function} = rule.u(Δ, args...)
@@ -214,4 +217,3 @@ function AbstractRule(𝒟::Type, primal::AbstractRule, conjugate::AbstractRule)
         return WirtingerRule(primal, conjugate)
     end
 end
-

--- a/test/rule_types.jl
+++ b/test/rule_types.jl
@@ -12,6 +12,15 @@
         @test_throws BoundsError rule[2]
     end
 
+    @testset "Rule" begin
+        @testset "show" begin
+            @test occursin(r"^Rule\(.*foo.*\)$", repr(Rule(function foo() 1 end)))
+            @test occursin(r"^Rule\(.*identity.*\)$", repr(Rule(identity)))
+
+            @test occursin(r"^Rule\(.*identity.*\,.*\+.*\)$", repr(Rule(identity, +)))
+        end
+    end
+
     @testset "WirtingerRule" begin
         myabs2(x) = abs2(x)
 


### PR DESCRIPTION
I have some ideas about improving it more,
but this at least avoids showing unneeded type-params.
So it is a bit simpler to read.
But still can be recreated from input.