### PR TITLE
implement `transpose(::AbstractDifferential)`

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -40,6 +40,7 @@ wrapped by `x`, such that mutating `extern(x)` might mutate `x` itself.
 @inline extern(x) = x
 
 @inline Base.conj(x::AbstractDifferential) = x
+@inline Base.transpose(x::AbstractDifferential) = x
 
 #####
 ##### `Wirtinger`
@@ -196,13 +197,18 @@ Base.Broadcast.broadcastable(x::Thunk) = broadcastable(extern(x))
 
 @inline function Base.iterate(x::Thunk)
     externed = extern(x)
-    element, state = iterate(externed)
+    next = iterate(externed)
+    next === nothing && return nothing
+    element, state = next
     return element, (externed, state)
 end
 
 @inline function Base.iterate(::Thunk, (externed, state))
-    element, new_state = iterate(externed, state)
+    next = iterate(externed, state)
+    next === nothing && return nothing
+    element, new_state = next
     return element, (externed, new_state)
 end
 
 Base.conj(x::Thunk) = @thunk(conj(extern(x)))
+Base.transpose(x::Union{Thunk,Casted}) = @thunk(transpose(extern(x)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,8 @@ using ChainRulesCore
 using LinearAlgebra: Diagonal
 using ChainRulesCore: extern, accumulate, accumulate!, store!, @scalar_rule,
     Wirtinger, wirtinger_primal, wirtinger_conjugate,
-    Zero, One, Casted, cast,
-    DNE, Thunk, Casted, DNERule, WirtingerRule
+    Zero, One, Casted, cast, DNE, Thunk, @thunk,
+    DNERule, WirtingerRule
 using Base.Broadcast: broadcastable
 
 @testset "ChainRulesCore" begin


### PR DESCRIPTION
To implement correct derivatives for `transpose` and `adjoint`, we need to be able to transpose differentials. I will make a PR for those in `ChainRules.jl`, once this is merged. In the long run, it might be useful to make `AbstractDifferential <: AbstractArray`, to make use of the existing generic definitions and also allow things like `reshape` as well, but that should be a separate discussion.