### PR TITLE
no doctests

### DIFF
--- a/src/rule_types.jl
+++ b/src/rule_types.jl
@@ -11,7 +11,7 @@ return that calculated differential value.
 
 For example:
 
-```jldoctest
+```
 julia> using ChainRulesCore: frule, rrule, AbstractRule
 
 julia> x, y = rand(2);

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -65,7 +65,7 @@ Examples:
 
 unary input, unary output scalar function:
 
-```jldoctest
+```
 julia> x = rand();
 
 julia> sinx, dsin = frule(sin, x);
@@ -79,7 +79,7 @@ true
 
 unary input, binary output scalar function:
 
-```jldoctest
+```
 julia> x = rand();
 
 julia> sincosx, (dsin, dcos) = frule(sincos, x);
@@ -121,7 +121,7 @@ Examples:
 
 unary input, unary output scalar function:
 
-```jldoctest
+```
 julia> x = rand();
 
 julia> sinx, dx = rrule(sin, x);
@@ -135,7 +135,7 @@ true
 
 binary input, unary output scalar function:
 
-```jldoctest
+```
 julia> x, y = rand(2);
 
 julia> hypotxy, (dx, dy) = rrule(hypot, x, y);


### PR DESCRIPTION
ChainRulesCore doesn't define any rules,
so we can't have doctests that rely on them.
