### PR TITLE
WIP: Wirtinger support

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -63,10 +63,6 @@ The two fields of the returned instance can be accessed generically via the
 struct Wirtinger{P,C} <: AbstractDifferential
     primal::P
     conjugate::C
-    function Wirtinger(primal::Union{Number,AbstractDifferential},
-                       conjugate::Union{Number,AbstractDifferential})
-        return new{typeof(primal),typeof(conjugate)}(primal, conjugate)
-    end
 end
 
 wirtinger_primal(x::Wirtinger) = x.primal


### PR DESCRIPTION
As discussed in #40, Wirtinger support is going to be moved out of master for now. I'm going to start working on it in this branch, but might eventually decide to move this into a package.

My current plans for this so far are:

- [x]  remove type constraints for Wirtinger (since pretty much anything can be a differential, these don't make much sense to me anymore)
- [ ] make `wirtinger_[primal|conjugate]` recursive, to work better for things like `Thunk`s
- [ ] introduce a type `ComplexGradient`, which works like Zygote's complex derivatives to address #23 and make porting Zygote to ChainRules easier
- [ ] introduce an abstract type `AbstractWirtinger`, which `Wirtinger` as well as `ComplexGradient` are a subtype of
- [ ] a function `chain` which works mostly like `*`, but respects, which function is the derivative of the outer/inner function, which is important for `AbstractWirtinger` differentials
- [ ] simplify `@scalar_rule` with this `chain` function
- [ ] disallow multiplication of complex numbers with `AbstractWirtinger` and require users to use `chain`, since the order of chaining matters here, too

I always appreciate any feedback.