### PR TITLE
Record where thunks actually created

### DIFF
--- a/src/differentials.jl
+++ b/src/differentials.jl
@@ -212,8 +212,17 @@ struct Thunk{F} <: AbstractThunk
     f::F
 end
 
+
+"""
+    @thunk expr
+
+Define a [`Thunk`](@ref) wrapping the `expr`, to lazily defer its evaluation.
+"""
 macro thunk(body)
-    return :(Thunk(() -> $(esc(body))))
+    # Basically `:(Thunk(() -> $(esc(body))))` but use the location where it is defined.
+    # so we get useful stack traces if it errors.
+    func = Expr(:->, Expr(:tuple), Expr(:block, __source__, body))
+    return :(Thunk($(esc(func))))
 end
 
 # have to define this here after `@thunk` and `Thunk` is defined

--- a/test/differentials.jl
+++ b/test/differentials.jl
@@ -66,6 +66,21 @@
             @test (@thunk(3))() == 3
             @test (@thunk(@thunk(3)))() isa Thunk
         end
+
+        @testset "erroring thunks should include the source in the backtrack" begin
+            expected_line = (@__LINE__) + 2  # for testing it is at right palce
+            try
+                x = @thunk(error())
+                extern(x)
+            catch err
+                err isa ErrorException || rethrow()
+                st = stacktrace(catch_backtrace())
+                # Should be 2nd last line, as last line will be the `error` function
+                stackframe = st[2]
+                @test stackframe.line == expected_line
+                @test stackframe.file == Symbol(@__FILE__)
+            end
+        end
     end
 
     @testset "No ambiguities in $f" for f in (+, *)


### PR DESCRIPTION
Is this enough to close #57 ?

Should I test this? Maybe can throw error, then access the backtrack as a string,
and then make sure the right file name occurs?

### Before
```
julia> demo_pb() = @thunk(error("no"))
demo_pb (generic function with 1 method)

julia> extern(demo_pb())
ERROR: no
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] (::var"#15#16")() at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/differentials.jl:216
 [3] (::Thunk{var"#15#16"})() at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/differentials.jl:223
 [4] extern(::Thunk{var"#15#16"}) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/differentials.jl:224
 [5] top-level scope at REPL[12]:1
```

### After

```
julia> extern(demo_pb())
ERROR: no
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] (::var"#13#14")() at ./REPL[9]:1
 [3] (::Thunk{var"#13#14"})() at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/differentials.jl:232
 [4] extern(::Thunk{var"#13#14"}) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/differentials.jl:233
 [5] top-level scope at REPL[10]:1
```

Note that in the real use case when not testing it in the REPL
will whow a filename and line number rather than
` [2] (::var"#13#14")() at ./REPL[9]:1`
