### PR TITLE
add Unthunk

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.4.0"
+version = "0.5.0-DEV"
 
 [compat]
 julia = "^1.0"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -4,7 +4,7 @@ using Base.Broadcast: materialize, materialize!, broadcasted, Broadcasted, broad
 export frule, rrule
 export wirtinger_conjugate, wirtinger_primal, refine_differential
 export @scalar_rule, @thunk
-export extern, store!
+export extern, store!, unthunk
 export Wirtinger, Zero, One, DoesNotExist, Thunk, InplaceableThunk
 export NO_FIELDS
 

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -78,12 +78,12 @@ for T in (:AbstractThunk, :Any)
 end
 
 
-Base.:+(a::AbstractThunk, b::AbstractThunk) = extern(a) + extern(b)
-Base.:*(a::AbstractThunk, b::AbstractThunk) = extern(a) * extern(b)
+Base.:+(a::AbstractThunk, b::AbstractThunk) = unthunk(a) + unthunk(b)
+Base.:*(a::AbstractThunk, b::AbstractThunk) = unthunk(a) * unthunk(b)
 for T in (:Any,)
-    @eval Base.:+(a::AbstractThunk, b::$T) = extern(a) + b
-    @eval Base.:+(a::$T, b::AbstractThunk) = a + extern(b)
+    @eval Base.:+(a::AbstractThunk, b::$T) = unthunk(a) + b
+    @eval Base.:+(a::$T, b::AbstractThunk) = a + unthunk(b)
 
-    @eval Base.:*(a::AbstractThunk, b::$T) = extern(a) * b
-    @eval Base.:*(a::$T, b::AbstractThunk) = a * extern(b)
+    @eval Base.:*(a::AbstractThunk, b::$T) = unthunk(a) * b
+    @eval Base.:*(a::$T, b::AbstractThunk) = a * unthunk(b)
 end

--- a/test/differentials.jl
+++ b/test/differentials.jl
@@ -62,6 +62,11 @@
             @test extern(@thunk(@thunk(3))) == 3
         end
 
+        @testset "unthunk" begin
+            @test unthunk(@thunk(3)) == 3
+            @test unthunk(@thunk(@thunk(3))) isa Thunk
+        end
+
         @testset "calling thunks should call inner function" begin
             @test (@thunk(3))() == 3
             @test (@thunk(@thunk(3)))() isa Thunk


### PR DESCRIPTION
This swaps `extern` for `unthunk`
which just removes a layer of thunking,
rather than attempting to fully get from a differential to a primal

It is needed for #61  but is distrinct (that PR currently sits ontop of this one though)

Note that even in double thunking cases:
`1+@thunk(@thunk(2))` becomes `1 + @thunk(2)` becomes `1+2`
so addition is still fine.

This also occurs in #54 