### PR TITLE
move integration tests over to CirrusCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,8 @@ task:
   build_script:
     - cirrusjl build
   test_script:
-    - git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
+    - pkg install -y git
+    - julia git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
     # This is a special integration test to see if we broke ChainRules.jl with latest ChainRulesCore.jl changes 
     # Start julia with  the project set to newly cloned subdir ChainRules.jl
     # dev the current directory to get the version of ChainRulesCore that we are testing

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ task:
     - cirrusjl build
   test_script:
     - pkg install -y git
-    - julia git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
+    - git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
     # This is a special integration test to see if we broke ChainRules.jl with latest ChainRulesCore.jl changes 
     # Start julia with  the project set to newly cloned subdir ChainRules.jl
     # dev the current directory to get the version of ChainRulesCore that we are testing

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.2
+      - JULIA_VERSION: 1.3
+      - JULIA_VERSION: nightly
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
+    # Start julia with  the project set to newly cloned subdir ChainRules.jl
+    # dev the current directory to get the version of ChainRulesCore that we are testing
+    # update everything to resolve and sortout any versions,
+    # finally test the ChainRules.jl
+    - julia --project="ChainRules.jl" -e "using Pkg; Pkg.pkg\"dev .\"; Pkg.pkg\"up\"; Pkg.pkg\"test\""

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,7 @@ task:
   env:
     matrix:
       - JULIA_VERSION: 1.0
-      - JULIA_VERSION: 1.2
       - JULIA_VERSION: 1.3
-      - JULIA_VERSION: nightly
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ task:
     - cirrusjl build
   test_script:
     - git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
+    # This is a special integration test to see if we broke ChainRules.jl with latest ChainRulesCore.jl changes 
     # Start julia with  the project set to newly cloned subdir ChainRules.jl
     # dev the current directory to get the version of ChainRulesCore that we are testing
     # update everything to resolve and sortout any versions,

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_instance:
   image: freebsd-12-0-release-amd64
 task:
-  name: FreeBSD
+  name: ChainRules.jl (dep test)
   env:
     matrix:
       - JULIA_VERSION: 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,3 @@ notifications:
 after_success:
   # push coverage results to Coveralls
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
-
-jobs:
-  include:
-    # Make sure ChainRules.jl works with this
-    - state: Integration
-      name: ChainRules master integration tests
-      julia: 1.0
-      os: linux
-      script:
-        - git clone "https://github.com/JuliaDiff/ChainRules.jl.git"
-        # Start julia with  the project set to newly cloned subdir ChainRules.jl
-        # dev the current directory to get the version of ChainRulesCore that we are testing
-        # update everything to resolve and sortout any versions,
-        # finally test the ChainRules.jl
-        - julia --project="ChainRules.jl" -e "using Pkg; Pkg.pkg\"dev .\"; Pkg.pkg\"up\"; Pkg.pkg\"test\""
-      after_success: skip


### PR DESCRIPTION
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/5127634/68046789-9aaff580-fcd4-11e9-8d75-38d1234fffab.png">
As shown above (and below) now they will be shown seperately
The FreeBSD ones are for ChainRules.jl integration tests.
The TravisCI ones are for the ChainRulesCore.jl unit tests


It was getting annoying not being able to see from a PR if it was just integration tests failing.
(Which could be expected)
Or if it was also unit tests

This close #49 