### PR TITLE
remove thunking in @scalar_rule

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -256,7 +256,7 @@ function wirtinger_propagation_expr(𝒟, wirtinger_indices, Δs, ∂s)
             push!(∂_mul_Δs_primal, :($∂f∂i_mul_Δ + $∂f∂ī_mul_Δ̄))
             push!(∂_mul_Δs_conjugate, :($∂f̄∂i_mul_Δ + $∂f̄∂ī_mul_Δ̄))
         else
-            ∂_mul_Δ = :($(∂s[i])) * $(Δs[i]))
+            ∂_mul_Δ = :($(∂s[i]) * $(Δs[i]))
             push!(∂_mul_Δs_primal, ∂_mul_Δ)
             push!(∂_mul_Δs_conjugate, ∂_mul_Δ)
         end

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -236,11 +236,7 @@ end
 
 function standard_propagation_expr(Δs, ∂s)
     # This is basically Δs ⋅ ∂s
-
-    # Notice: the thunking of `∂s[i] (potentially) saves us some computation
-    # if `Δs[i]` is a `AbstractDifferential` otherwise it is computed as soon
-    # as the pullback is evaluated
-    ∂_mul_Δs = [:(@thunk($(∂s[i])) * $(Δs[i])) for i in 1:length(∂s)]
+    ∂_mul_Δs = ntuple(i->:($(∂s[i]) * $(Δs[i])), length(∂s))
     return :(+($(∂_mul_Δs...)))
 end
 
@@ -260,7 +256,7 @@ function wirtinger_propagation_expr(𝒟, wirtinger_indices, Δs, ∂s)
             push!(∂_mul_Δs_primal, :($∂f∂i_mul_Δ + $∂f∂ī_mul_Δ̄))
             push!(∂_mul_Δs_conjugate, :($∂f̄∂i_mul_Δ + $∂f̄∂ī_mul_Δ̄))
         else
-            ∂_mul_Δ = :(@thunk($(∂s[i])) * $(Δs[i]))
+            ∂_mul_Δ = :($(∂s[i])) * $(Δs[i]))
             push!(∂_mul_Δs_primal, ∂_mul_Δ)
             push!(∂_mul_Δs_conjugate, ∂_mul_Δ)
         end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -132,11 +132,11 @@ end
         fx, f_pushforward = res
         df(Δx, Δp) = f_pushforward(NamedTuple(), Δx, Δp)
 
-        df_dx::Thunk = df(One(), Zero())
-        df_dp::Thunk = df(Zero(), One())
+        df_dx = df(One(), Zero())
+        df_dp = df(Zero(), One())
         @test fx == f(x, p)  # Check we still get the normal value, right
-        @test df_dx() isa expected_type_df_dx
-        @test df_dp() isa expected_type_df_dp
+        @test df_dx isa expected_type_df_dx
+        @test df_dp isa expected_type_df_dp
 
 
         res = rrule(f, x, p)
@@ -145,7 +145,7 @@ end
         dself, df_dx, df_dp = f_pullback(One())
         @test fx == f(x, p)  # Check we still get the normal value, right
         @test dself == NO_FIELDS
-        @test df_dx() isa expected_type_df_dx
-        @test df_dp() isa expected_type_df_dp
+        @test df_dx isa expected_type_df_dx
+        @test df_dp isa expected_type_df_dp
     end
 end


### PR DESCRIPTION
It was pointless.

Either:
 - There was 1 derivative being propagated, in which case there should not have been any thunking (see docs added in #75)
 - Or there was multiple, in which case they all get unthunked when the `+` happens.