### PR TITLE
Bring back nongenerated backing

### DIFF
--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,3 +1,23 @@
 if VERSION < v"1.2"
     Base.getproperty(x::Tuple, f::Int) = getfield(x, f)
 end
+
+if VERSION < v"1.1"
+    # Note: these are actually *better* than the ones in julia 1.1, 1.2, 1.3,and 1.4
+    # See: https://github.com/JuliaLang/julia/issues/34292
+    function fieldtypes(::Type{T}) where T
+        if @generated
+            ntuple(i -> fieldtype(T, i), fieldcount(T))
+        else
+            ntuple(i -> fieldtype(T, i), fieldcount(T))
+        end
+    end
+
+    function fieldnames(::Type{T}) where T
+        if @generated
+            ntuple(i -> fieldname(T, i), fieldcount(T))
+        else
+            ntuple(i -> fieldname(T, i), fieldcount(T))
+        end
+    end
+end

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -77,7 +77,6 @@ backing(x::Tuple) = x
 backing(x::NamedTuple) = x
 backing(x::Composite) = getfield(x, :backing)
 
-
 function backing(x::T)::NamedTuple where T
     # note: all computation outside the if @generated happens at runtime.
     # so the first 4 lines of the branchs look the same, but can not be moved out.

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -77,16 +77,6 @@ backing(x::Tuple) = x
 backing(x::NamedTuple) = x
 backing(x::Composite) = getfield(x, :backing)
 
-function backing(x)::NamedTuple
-    
-
-    else
-        !isstructtype(x) && throw(DomainError(x, "backing can only be use on composite types"))
-        nfields = fieldcount(x)
-        names = ntuple(ii->fieldname(x, ii), nfields)
-        types = ntuple(ii->fieldtype(x, ii), nfields)
-
-end
 
 function backing(x::T)::NamedTuple where T
     # note: all computation outside the if @generated happens at runtime.
@@ -95,16 +85,16 @@ function backing(x::T)::NamedTuple where T
     if @generated
         !isstructtype(T) && throw(DomainError(T, "backing can only be use on composite types"))
         nfields = fieldcount(T)
-        names = ntuple(ii->fieldname(T, ii), nfields)
-        types = ntuple(ii->fieldtype(T, ii), nfields)
+        names = fieldnames(T)
+        types = fieldtypes(T)
         
         vals = Expr(:tuple, ntuple(ii->:(getfield(x, $ii)), nfields)...)
         return :(NamedTuple{$names, Tuple{$(types...)}}($vals))
     else
         !isstructtype(T) && throw(DomainError(T, "backing can only be use on composite types"))
         nfields = fieldcount(T)
-        names = ntuple(ii->fieldname(T, ii), nfields)
-        types = ntuple(ii->fieldtype(T, ii), nfields)
+        names = fieldnames(T)
+        types = fieldtypes(T)
 
         vals = ntuple(ii->getfield(x, ii), nfields)
         return NamedTuple{names, Tuple{types...}}(vals)


### PR DESCRIPTION
Partially undoes #81 
in light of https://github.com/JuliaLang/julia/issues/34283


Turns out putting code outside the `if @generated` causes it to always run at runtime