### PR TITLE
remove scalar thunking (attempt 2)

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -215,10 +215,7 @@ function propagation_expr(Δs, ∂s)
     # This is basically Δs ⋅ ∂s
     ∂s = map(esc, ∂s)
 
-    # Notice: the thunking of `∂s[i] (potentially) saves us some computation
-    # if `Δs[i]` is a `AbstractDifferential` otherwise it is computed as soon
-    # as the pullback is evaluated
-    ∂_mul_Δs = [:(@thunk($(∂s[i])) * $(Δs[i])) for i in 1:length(∂s)]
+    ∂_mul_Δs = ntuple(i->:($(∂s[i]) * $(Δs[i])), length(∂s))
     return :(+($(∂_mul_Δs...)))
 end
 


### PR DESCRIPTION
This replaces #76 
just because it was annoying to rebase.

Motivation remains:

> It was pointless.
> 
> Either:
> 
>     There was 1 derivative being propagated, in which case there should not have been any thunking (see docs added in #75)
>     Or there was multiple, in which case they all get unthunked when the + happens.
> 