### PR TITLE
Allow failures on 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ julia:
 jobs:
   allow_failures:
     - julia: nightly
+    - julia: 1.4
   include:
     - stage: "Documentation"
       julia: 1.0


### PR DESCRIPTION
At some point we can look into changing this, I think it is to `@allocated` changing 
(and we now have `BenchmarkTools.@ballocated`)

but first we should let 1.4 get released