### PR TITLE
Export AbstractThunk

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -4,7 +4,7 @@ using Base.Broadcast: broadcasted, Broadcasted, broadcastable, materialize, mate
 export frule, rrule
 export @scalar_rule, @thunk
 export canonicalize, extern, unthunk
-export Composite, DoesNotExist, InplaceableThunk, One, Thunk, Zero, AbstractZero
+export Composite, DoesNotExist, InplaceableThunk, One, Thunk, Zero, AbstractZero, AbstractThunk
 export NO_FIELDS
 
 include("compat.jl")


### PR DESCRIPTION
- useful for https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/20/files#diff-234b922abbcf04ec39f433cf6ce21772R17 where adding a method for `AbstractThunk` makes more sense (to me) than `AbstractDifferential`
