### PR TITLE
Add Debug Mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ DocMeta.setdocmeta!(
         Random.seed!(0)  # frule doctest shows output
 
         using ChainRulesCore
-        # These rules are all actually defined in ChainRules.jl, but we redefine them here to 
+        # These rules are all actually defined in ChainRules.jl, but we redefine them here to
         # avoid the dependency.
         @scalar_rule(sin(x), cos(x))  # frule and rrule doctest
         @scalar_rule(sincos(x), @setup((sinx, cosx) = Ω), cosx, -sinx)  # frule doctest
@@ -28,6 +28,7 @@ makedocs(
         "Introduction" => "index.md",
         "FAQ" => "FAQ.md",
         "Writing Good Rules" => "writing_good_rules.md",
+        "Debug Mode" => "debug_mode.md",
         "API" => "api.md",
     ],
     strict=true,

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -30,4 +30,5 @@ Private = false
 ## Internal
 ```@docs
 ChainRulesCore.AbstractDifferential
+ChainRulesCore.debug_mode
 ```

--- a/docs/src/debug_mode.md
+++ b/docs/src/debug_mode.md
@@ -1,13 +1,13 @@
 # Debug Mode
 
-ChainRules supports a *debug mode* which you can use while writing new rules.
+ChainRulesCore supports a *debug mode* which you can use while writing new rules.
 It provides better error messages.
 If you are developing some new rules, and you get a weird error message,
 it is worth enabling debug mode.
 
 There is some overhead to having it enabled, so it is disabled by default.
 
-To enable redefine the []`ChainRulesCore.debug_mode`](@ref) function to return `true`.
+To enable, redefine the [`ChainRulesCore.debug_mode`](@ref) function to return `true`.
 ```julia
 ChainRulesCore.debug_mode() = true
 ```

--- a/docs/src/debug_mode.md
+++ b/docs/src/debug_mode.md
@@ -1,13 +1,13 @@
 # Debug Mode
 
-ChainRules supports a [`debug_mode`](@ref) which you can use while writing new rules.
+ChainRules supports a *debug mode* which you can use while writing new rules.
 It provides better error messages.
 If you are developing some new rules, and you get a weird error message,
 it is worth enabling debug mode.
 
 There is some overhead to having it enabled, so it is disabled by default.
 
-To enable redefine the `debug_mode()` function to return `true`.
+To enable redefine the []`ChainRulesCore.debug_mode`](@ref) function to return `true`.
 ```julia
 ChainRulesCore.debug_mode() = true
 ```

--- a/docs/src/debug_mode.md
+++ b/docs/src/debug_mode.md
@@ -1,0 +1,13 @@
+# Debug Mode
+
+ChainRules supports a [`debug_mode`](@ref) which you can use while writing new rules.
+It provides better error messages.
+If you are developing some new rules, and you get a weird error message,
+it is worth enabling debug mode.
+
+There is some overhead to having it enabled, so it is disabled by default.
+
+To enable redefine the `debug_mode()` function to return `true`.
+```julia
+ChainRulesCore.debug_mode() = true
+```

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -8,6 +8,7 @@ export Composite, DoesNotExist, InplaceableThunk, One, Thunk, Zero, AbstractZero
 export NO_FIELDS
 
 include("compat.jl")
+include("debug_mode.jl")
 
 include("differentials/abstract_differential.jl")
 include("differentials/abstract_zero.jl")

--- a/src/debug_mode.jl
+++ b/src/debug_mode.jl
@@ -1,5 +1,5 @@
 """
-    debug_mode()
+    debug_mode() -> Bool
 
 Determines if ChainRulesCore is in `debug_mode`.
 Defaults to `false`, but if the user redefines it to return `true` then extra

--- a/src/debug_mode.jl
+++ b/src/debug_mode.jl
@@ -1,0 +1,13 @@
+"""
+    debug_mode()
+
+Determines if ChainRulesCore is in `debug_mode`.
+Defaults to `false`, but if the user redefines it to return `true` then extra
+information will be shown when errors occur.
+
+Enable via:
+```
+ChainRulesCore.debug_mode() = true
+```
+"""
+debug_mode() = false

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -86,10 +86,15 @@ function Base.:+(a::Composite{P}, b::Composite{P}) where P
     return Composite{P, typeof(data)}(data)
 end
 function Base.:+(a::P, d::Composite{P}) where P
-    try
-        return construct(P, elementwise_add(backing(a), backing(d)))
-    catch err
-        throw(PrimalAdditionFailedException(a, d, err))
+    net_backing = elementwise_add(backing(a), backing(d))
+    if debug_mode()
+        try
+            return construct(P, net_backing)
+        catch err
+            throw(PrimalAdditionFailedException(a, d, err))
+        end
+    else
+        return construct(P, net_backing)
     end
 end
 Base.:+(a::Composite{P}, b::P) where P = b + a

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -128,8 +128,19 @@ end
     @testset "+ with Primals, with inner constructor" begin
         value = StructWithInvariant(10.0)
         diff = Composite{StructWithInvariant}(x=2.0, x2=6.0)
-        @test_throws ChainRulesCore.PrimalAdditionFailedException (value + diff)
-        @test_throws ChainRulesCore.PrimalAdditionFailedException (diff + value)
+
+        @testset "with and without debug mode" begin
+            @assert ChainRulesCore.debug_mode() == false
+            @test_throws MethodError (value + diff)
+            @test_throws MethodError (diff + value)
+
+            ChainRulesCore.debug_mode() = true  # enable debug mode
+            @test_throws ChainRulesCore.PrimalAdditionFailedException (value + diff)
+            @test_throws ChainRulesCore.PrimalAdditionFailedException (diff + value)
+            ChainRulesCore.debug_mode() = false  # disable it again
+        end
+
+
 
         # Now we define constuction for ChainRulesCore.jl's purposes:
         # It is going to determine the root quanity of the invarient


### PR DESCRIPTION
closes #82 

Gives us full performance for addition of primal and differential,
at the cost of the good error message.

But by enabling the `ChainRulesCore.debug_mode() = true`
the good error message comes back.


```julia
julia> using ChainRulesCore, BenchmarkTools

julia> struct Foo
           x::Float64
       end

julia> foo = Foo(0.5)
Foo(0.5)

julia> Δfoo = Composite{typeof(foo)}(; x=0.4)
Composite{Foo}(x = 0.4,)

julia> @benchmark $foo + $Δfoo  # good performance
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.247 ns (0.00% GC)
  median time:      1.465 ns (0.00% GC)
  mean time:        1.439 ns (0.00% GC)
  maximum time:     15.312 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000

julia> ChainRulesCore.debug_mode() = true

julia> @benchmark $foo + $Δfoo  # bad performance
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     20.395 ns (0.00% GC)
  median time:      22.274 ns (0.00% GC)
  mean time:        23.668 ns (0.00% GC)
  maximum time:     156.394 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     997
```