### PR TITLE
[WIP] Implement has_frule + has_rrule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -50,6 +50,14 @@ See also: [`rrule`](@ref), [`@scalar_rule`](@ref)
 frule(::Any, ::Vararg{Any}; kwargs...) = nothing
 
 """
+A docstring
+"""
+function has_frule(args::Tuple)
+    ret_types = Base.return_types(frule, args)
+    return first(ret_types) !== Nothing
+end
+
+"""
     rrule(f, x...)
 
 Expressing `x` as the tuple `(x₁, x₂, ...)` and the output tuple of `f(x...)`
@@ -96,3 +104,11 @@ true
 See also: [`frule`](@ref), [`@scalar_rule`](@ref)
 """
 rrule(::Any, ::Vararg{Any}; kwargs...) = nothing
+
+"""
+A docstring
+"""
+function has_rrule(args::Tuple)
+    ret_types = Base.return_types(rrule, args)
+    return first(ret_types) != Nothing
+end


### PR DESCRIPTION
Partly addresses option 2 in [the Zygote-ChainRules PR](https://github.com/FluxML/Zygote.jl/pull/366).

Figured this is probably a helpful thing to have in ChainRules, anyway.

Questions:

- ~~what's the right way to handle kwargs?~~ edit: we don't have an answer for this at the minute, so possible not addressable right now.
- are there any obvious edge cases that I'm missing?
- do we want a more pleasant interface for `frule`? (I think the one for `rrule` is okay)

TODO:

- [ ] resolve above questions
- [ ] documentation