### PR TITLE
Replace Heavier Math section with Geometeric section

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -138,7 +138,7 @@ The collection of tangent spaces ``{T_pM}`` for ``p\in M`` is called the _tangen
 
 Let ``df`` denote the first order information of ``f`` at each point. This is called the differential of ``f``. 
 If the derivatives of ``f`` and ``g`` agree at ``p``, we say that ``df`` and ``dg`` represent the same cotangent at ``p``.
-The covectors ``dx_1, ..., dx_m`` form the basis of the cotangent space T^*_pM at ``p``. Notice that this vector space is 
+The covectors ``dx_1, ..., dx_m`` form the basis of the cotangent space ``T^*_pM`` at ``p``. Notice that this vector space is 
 dual to ``T_p``
 
 The collection of cotangent spaces ``{T^*_pM}`` for ``p\in M`` is called the _cotangent bundle_ of ``M``.
@@ -149,10 +149,10 @@ Let ``N`` be another type, defined by numbers ``y_1,...,y_n``, and let ``g:M -> 
 an ``n``-dimensional vector ``(g_1, ..., g_m)`` of functions on ``M``.
 
 We define the _push-forward_ ``g_*:TM -> TN`` between tangent bundles by ``g_*(X)(h) = X(g\circ h)`` for any tangent vector ``X`` and function ``f``.
-We have ``g_*(d/dx_i)(y_j) = dg_j/dx_i, so the push-forward corresponds to the Jacobian, given a chosen basis.
+We have ``g_*(d/dx_i)(y_j) = dg_j/dx_i``, so the push-forward corresponds to the Jacobian, given a chosen basis.
 
 Similarly, the pullback of the differential ``df`` is defined by
-``g^*(df) = d(g\circ f)``. So for a coordinate differential ``dy_j``, we have
+``g^*(df) = d(f\circ g)``. So for a coordinate differential ``dy_j``, we have
 ``g^*(dy_j) = d(g_j)``. Notice that this is a covector, and we could have defined the pullback by its action on vectors by
 ``g^*(dh)(X) = g_*(X)(dh) = X(g\circ h)`` for any function ``f`` on ``N`` and ``X\in TM``. In particular, 
 ``g^*(dy_j)(d/dx_i) = d(g_j)/dx_i``. If you work out the action in a basis of the cotangent space, you see that it acts

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -118,21 +118,67 @@ applies the chain rule to go from `∂c/∂b` to `∂c/∂a`.
 The pushforward of `g`,  which also incorporates the knowledge of `∂b/∂a`,
 applies the chain rule to go from `∂a/∂x` to `∂b/∂x`.
 
-### Heavier Math
-If I have some functions: ``g(a)``, ``h(b)`` and ``f(x)=g(h(x))``, and I know
-the pullback of ``g``, at ``h(x)`` written: ``\mathrm{pullback}_{g(a)|a=h(x)}``,
-and I know the derivative of ``h`` with respect to its input ``b`` at ``g(x)``,
-written: ``\left.\dfrac{∂h}{∂b}\right|_{b=g(x)}`` Then I can use the pullback to
-find: ``\dfrac{∂f}{∂x}``:
+##### Geometric interpretation of reverse and forwards mode AD
 
-``\dfrac{∂f}{∂x}=\mathrm{\mathrm{pullback}_{g(a)|a=h(x)}}\left(\left.\dfrac{∂h}{∂b}\right|_{b=g(x)}\right).``
+Let us think of our types geometrically. In other words, elements of a type form a _manifold_.
+This document will explain this point of view in some detail.
 
-If I know the derivative of ``g`` with respect to its input a at ``x``, written:
-``\left.\dfrac{∂g}{∂a}\right|_{a=x}``, and I know the pushforward of ``h`` at
-``g(x)`` written: ``\mathrm{pushforward}_{h(b)|b=g(x)}``. Then I can use the
-pushforward to find ``\dfrac{∂f}{∂x}``:
+###### Some terminology/conventions.
 
-``\dfrac{∂f}{∂x}=\mathrm{pushforward}_{h(b)|b=g(x)}\left(\left.\dfrac{∂g}{∂a}\right|_{a=x}\right)``
+Let ``p`` be an element of type M, which is defined by some assignment of numbers ``x_1,...,x_m``,
+say ``(x_1,...,x_m) = (a_1,...,1_m)`` 
+
+A _function_ ``f:M -> K`` on ``M`` is (for simplicity) a polynomial ``K[x_1, ... x_m]``
+
+The tangent space ``T_pM`` of ``T`` at point ``p`` is the ``K``-vector space spanned by derivations ``d/dx``. 
+The tangent space acts linearly on the space of functions. They act as usual on functions. Our starting point is 
+that we know how to write down ``d/dx(f) = df/dx``.
+
+The collection of tangent spaces ``{T_pM}`` for ``p\in M`` is called the _tangent bundle_ of ``M``.
+
+Let ``df`` denote the first order information of ``f`` at each point. This is called the differential of ``f``. 
+If the derivatives of ``f`` and ``g`` agree at ``p``, we say that ``df`` and ``dg`` represent the same cotangent at ``p``.
+The covectors ``dx_1, ..., dx_m`` form the basis of the cotangent space T^*_pM at ``p``. Notice that this vector space is 
+dual to ``T_p``
+
+The collection of cotangent spaces ``{T^*_pM}`` for ``p\in M`` is called the _cotangent bundle_ of ``M``.
+
+###### Push-forwards and pullbacks
+
+Let ``N`` be another type, defined by numbers ``y_1,...,y_n``, and let ``g:M -> N`` be a _map_, that is, 
+an ``n``-dimensional vector ``(g_1, ..., g_m)`` of functions on ``M``.
+
+We define the _push-forward_ ``g_*:TM -> TN`` between tangent bundles by ``g_*(X)(h) = X(g\circ h)`` for any tangent vector ``X`` and function ``f``.
+We have ``g_*(d/dx_i)(y_j) = dg_j/dx_i, so the push-forward corresponds to the Jacobian, given a chosen basis.
+
+Similarly, the pullback of the differential ``df`` is defined by
+``g^*(df) = d(g\circ f)``. So for a coordinate differential ``dy_j``, we have
+``g^*(dy_j) = d(g_j)``. Notice that this is a covector, and we could have defined the pullback by its action on vectors by
+``g^*(dh)(X) = g_*(X)(dh) = X(g\circ h)`` for any function ``f`` on ``N`` and ``X\in TM``. In particular, 
+``g^*(dy_j)(d/dx_i) = d(g_j)/dx_i``. If you work out the action in a basis of the cotangent space, you see that it acts
+by the adjoint of the Jacobian.
+
+Notice that the pullback of a differential and the pushforward of a vector have a very different meaning, and this should
+be reflected on how they are used in code.
+
+The information contained in the push-forward map is exactly _what does my function do to tangent vectors_.
+Pullbacks, acting on differentials of functions, act by taking the total derivative of a function.
+This works in a coordinate invariant way, and works without the notion of a metric.
+_Gradients_ recall are vectors, yet they should contain the same information of the differential ``df``.
+Assuming we use the standard euclidean metric, we can identify ``df`` and ``\nabla f`` as vectors.
+But pulling back gradients still should not be a thing.
+
+If the goal is to evaluate the gradient of a function ``f=g\circ h:M -> N -> K``, where ``g`` is a map and ``h`` is a function,
+we have two obvious options:
+First, we may push-forward a basis of ``M`` to ``TK`` which we identify with K itself. 
+This results in ``m`` scalars, representing components of the gradient.
+Step-by-step in coordinates:
+1. Compute the push-forward of the basis of ``T_pM``, i.e. just the columns of the Jacobian ``dg_i/dx_j``.
+2. Compute the push-forward of the function ``h`` (consider it as a map, K is also a manifold!) to get ``h_*(g_*T_pM) = \sum_j dh/dy_i (dg_i/dx_j)
+
+Second, we pull back the differential ``dh``: 
+1. compute ``dh = dh/dy_1,...,dh/dy_n`` in coordinates.
+2. pull back by (in coordinates) multiplying with the adjoint of the Jacobian, resulting in ``g_*(dh) = \sum_i(dg_i/dx_j)(dh/dy_i)``.
 
 
 ### The anatomy of pullback and pushforward

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -128,7 +128,7 @@ This document will explain this point of view in some detail.
 Let ``p`` be an element of type M, which is defined by some assignment of numbers ``x_1,...,x_m``,
 say ``(x_1,...,x_m) = (a_1,...,1_m)`` 
 
-A _function_ ``f:M -> K`` on ``M`` is (for simplicity) a polynomial ``K[x_1, ... x_m]``
+A _function_ ``f:M \to K`` on ``M`` is (for simplicity) a polynomial ``K[x_1, ... x_m]``
 
 The tangent space ``T_pM`` of ``T`` at point ``p`` is the ``K``-vector space spanned by derivations ``d/dx``. 
 The tangent space acts linearly on the space of functions. They act as usual on functions. Our starting point is 
@@ -145,10 +145,10 @@ The collection of cotangent spaces ``{T^*_pM}`` for ``p\in M`` is called the _co
 
 ##### Push-forwards and pullbacks
 
-Let ``N`` be another type, defined by numbers ``y_1,...,y_n``, and let ``g:M -> N`` be a _map_, that is, 
+Let ``N`` be another type, defined by numbers ``y_1,...,y_n``, and let ``g:M \to N`` be a _map_, that is, 
 an ``n``-dimensional vector ``(g_1, ..., g_m)`` of functions on ``M``.
 
-We define the _push-forward_ ``g_*:TM -> TN`` between tangent bundles by ``g_*(X)(h) = X(g\circ h)`` for any tangent vector ``X`` and function ``f``.
+We define the _push-forward_ ``g_*:TM \to TN`` between tangent bundles by ``g_*(X)(h) = X(g\circ h)`` for any tangent vector ``X`` and function ``f``.
 We have ``g_*(d/dx_i)(y_j) = dg_j/dx_i``, so the push-forward corresponds to the Jacobian, given a chosen basis.
 
 Similarly, the pullback of the differential ``df`` is defined by
@@ -168,7 +168,7 @@ _Gradients_ recall are vectors, yet they should contain the same information of 
 Assuming we use the standard euclidean metric, we can identify ``df`` and ``\nabla f`` as vectors.
 But pulling back gradients still should not be a thing.
 
-If the goal is to evaluate the gradient of a function ``f=g\circ h:M -> N -> K``, where ``g`` is a map and ``h`` is a function,
+If the goal is to evaluate the gradient of a function ``f=g\circ h:M \to N \to K``, where ``g`` is a map and ``h`` is a function,
 we have two obvious options:
 First, we may push-forward a basis of ``M`` to ``TK`` which we identify with K itself. 
 This results in ``m`` scalars, representing components of the gradient.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -118,12 +118,12 @@ applies the chain rule to go from `∂c/∂b` to `∂c/∂a`.
 The pushforward of `g`,  which also incorporates the knowledge of `∂b/∂a`,
 applies the chain rule to go from `∂a/∂x` to `∂b/∂x`.
 
-##### Geometric interpretation of reverse and forwards mode AD
+#### Geometric interpretation of reverse and forwards mode AD
 
 Let us think of our types geometrically. In other words, elements of a type form a _manifold_.
 This document will explain this point of view in some detail.
 
-###### Some terminology/conventions.
+##### Some terminology/conventions.
 
 Let ``p`` be an element of type M, which is defined by some assignment of numbers ``x_1,...,x_m``,
 say ``(x_1,...,x_m) = (a_1,...,1_m)`` 
@@ -143,7 +143,7 @@ dual to ``T_p``
 
 The collection of cotangent spaces ``{T^*_pM}`` for ``p\in M`` is called the _cotangent bundle_ of ``M``.
 
-###### Push-forwards and pullbacks
+##### Push-forwards and pullbacks
 
 Let ``N`` be another type, defined by numbers ``y_1,...,y_n``, and let ``g:M -> N`` be a _map_, that is, 
 an ``n``-dimensional vector ``(g_1, ..., g_m)`` of functions on ``M``.
@@ -174,7 +174,7 @@ First, we may push-forward a basis of ``M`` to ``TK`` which we identify with K i
 This results in ``m`` scalars, representing components of the gradient.
 Step-by-step in coordinates:
 1. Compute the push-forward of the basis of ``T_pM``, i.e. just the columns of the Jacobian ``dg_i/dx_j``.
-2. Compute the push-forward of the function ``h`` (consider it as a map, K is also a manifold!) to get ``h_*(g_*T_pM) = \sum_j dh/dy_i (dg_i/dx_j)
+2. Compute the push-forward of the function ``h`` (consider it as a map, K is also a manifold!) to get ``h_*(g_*T_pM) = \sum_j dh/dy_i (dg_i/dx_j)``
 
 Second, we pull back the differential ``dh``: 
 1. compute ``dh = dh/dy_1,...,dh/dy_n`` in coordinates.


### PR DESCRIPTION
This takes @aisopous's PR from December that I never got round to merging,
and shifts it over here to where the docs are.
https://github.com/JuliaDiff/ChainRules.jl/pull/135
I think @aisopous addressed all comments there, explaining why the points were correct.

It also deletes the heavier math section which has issues. 
Since this section covers our need for rigerous math better than that section ever could.
This thus closes #139  

A follow up PR to breakup this page in the docs is needed.

---

Preview of Docs:
http://www.juliadiff.org/ChainRulesCore.jl/preview-PR147/#Geometric-interpretation-of-reverse-and-forwards-mode-AD-1