### PR TITLE
Remove misleading `zero(::DateTime)` example

### DIFF
--- a/docs/src/design/many_differentials.md
+++ b/docs/src/design/many_differentials.md
@@ -14,7 +14,7 @@ Beyond being a vector space, differentials need to be able to be added to a prim
 Or roughly equivalently a differential is a difference between two primal values.
 
 One thing to note in this example is that the primal does not have to be a vector.
-As an example, consider `DateTime`. A `DateTime` is not a vector space: there is no `zero(::DateTime)`, and `DateTime`s cannot be added to each other. The corresponding differential type is any subtype of `Period`, such as `Millisecond`, `Hour`, `Day` etc.
+As an example, consider `DateTime`. A `DateTime` is not a vector space: there is no origin point, and `DateTime`s cannot be added to each other. The corresponding differential type is any subtype of `Period`, such as `Millisecond`, `Hour`, `Day` etc.
     
 ## Natural differential
 


### PR DESCRIPTION
- following https://github.com/JuliaLang/julia/pull/35554
  which agrees with the point made here, but shows the
  given code to be misleading.
- i don't know if this is the best replacement text... maybe just delete that clause (since it is enough that  `DateTime`s cannot be added to each other