### PR TITLE
Differential addition for empty tuples fix in composite.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -36,6 +36,11 @@ function Composite{P}(args...) where P
     return Composite{P, typeof(args)}(args)
 end
 
+function Composite{P}() where P<:Tuple
+    backing = ()
+    return Composite{P, typeof(backing)}(backing)
+end
+
 function Base.show(io::IO, comp::Composite{P}) where P
     print(io, "Composite{")
     show(io, P)

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -20,6 +20,9 @@ end
 
 
 @testset "Composite" begin
+    @testset "empty types" begin
+        @test typeof(Composite{Tuple{}}()) == Composite{Tuple{}, Tuple{}}
+    end
     @testset "convert" begin
         @test convert(NamedTuple, Composite{Foo}(x=2.5)) == (; x=2.5)
         @test convert(Tuple, Composite{Tuple{Float64,}}(2.0)) == (2.0,)
@@ -88,7 +91,6 @@ end
         end
 
         @testset "Tuples" begin
-            @test typeof(Composite{Tuple{}}()) == Composite{Tuple{}, Tuple{}}
             @test ==(
                 typeof(Composite{Tuple{}}() + Composite{Tuple{}}()), 
                 Composite{Tuple{}, Tuple{}}

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -88,6 +88,11 @@ end
         end
 
         @testset "Tuples" begin
+            @test typeof(Composite{Tuple{}}()) == Composite{Tuple{}, Tuple{}}
+            @test ==(
+                typeof(Composite{Tuple{}}() + Composite{Tuple{}}()), 
+                Composite{Tuple{}, Tuple{}}
+            )
             @test (
                 Composite{Tuple{Float64, Float64}}(1.0, 2.0) +
                 Composite{Tuple{Float64, Float64}}(1.0, 1.0)
@@ -113,6 +118,7 @@ end
         end
 
         @testset "Tuples" begin
+            @test Composite{Tuple{}}() + () == ()
             @test ((1.0, 2.0) + Composite{Tuple{Float64, Float64}}(1.0, 1.0)) == (2.0, 3.0)
             @test (Composite{Tuple{Float64, Float64}}(1.0, 1.0)) + (1.0, 2.0) == (2.0, 3.0)
         end


### PR DESCRIPTION
Fix for issue [177](https://github.com/JuliaDiff/ChainRulesCore.jl/issues/177).  Case to explicitly deal with Composite being given zero arguments.