### PR TITLE
Add overloads of complex for One and Zero

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -67,6 +67,15 @@ Base.imag(::Zero) = Zero()
 Base.real(::One) = One()
 Base.imag(::One) = Zero()
 
+Base.complex(::Zero) = Zero()
+Base.complex(::Zero, ::Zero) = Zero()
+Base.complex(::Zero, i::Real) = complex(oftype(i, 0), i)
+Base.complex(r::Real, ::Zero) = complex(r)
+
+Base.complex(::One) = One()
+Base.complex(::Zero, ::One) = im
+Base.complex(::One, ::Zero) = One()
+
 Base.:+(a::One, b::One) = extern(a) + extern(b)
 Base.:*(::One, ::One) = One()
 for T in (:AbstractThunk, :Composite, :Any)

--- a/test/differentials/abstract_zero.jl
+++ b/test/differentials/abstract_zero.jl
@@ -49,6 +49,11 @@
         @test reim(z) === (Zero(), Zero())
         @test real(z) === Zero()
         @test imag(z) === Zero()
+
+        @test complex(z) === z
+        @test complex(z, z) === z
+        @test complex(z, 2.0) === Complex{Float64}(0.0, 2.0)
+        @test complex(1.5, z) === Complex{Float64}(1.5, 0.0)
     end
 
     @testset "DoesNotExist" begin

--- a/test/differentials/one.jl
+++ b/test/differentials/one.jl
@@ -16,4 +16,8 @@
     @test reim(o) === (One(), Zero())
     @test real(o) === One()
     @test imag(o) === Zero()
+
+    @test complex(o) === o
+    @test complex(o, Zero()) === o
+    @test complex(Zero(), o) === im
 end


### PR DESCRIPTION
Sometimes you want to use `complex(a, b)` instead of `a + im * b` in a rule, but it doesn't work if `a` or `b` end up being `Zero` or `One`. This adds the corresponding overloads for `Zero`, `One`, and mixtures of the two.