### PR TITLE
nondifferentiable macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.6"
+version = "0.9.7"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -4,7 +4,7 @@ using MuladdMacro: @muladd
 
 export on_new_rule, refresh_rules  # generation tools
 export frule, rrule  # core function
-export @scalar_rule, @thunk  # definition helper macros
+export @non_differentiable, @scalar_rule, @thunk  # definition helper macros
 export canonicalize, extern, unthunk  # differential operations
 # differentials
 export Composite, DoesNotExist, InplaceableThunk, One, Thunk, Zero, AbstractZero, AbstractThunk

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -254,11 +254,10 @@ propagator_name(fname::QuoteNode, propname::Symbol) = propagator_name(fname.valu
     @non_differentiable(signature_expression)
 
 A helper to make it easier to declare that a method is not not differentiable.
-This is a short-hand for defining a [`frule`](@ref) and an [`rrule`](@ref)+ pullback that 
-returns [`DoesNotExist()`](@ref) for all partials (except for the function `s̄elf`-partial
+This is a short-hand for defining an [`frule`](@ref) and [`rrule`](@ref) that 
+return [`DoesNotExist()`](@ref) for all partials (except for the function `s̄elf`-partial
 itself which is `NO_FIELDS`)
 
-The usage is to put the macro before a function signature.
 Keyword arguments should not be included.
 
 ```jldoctest
@@ -309,7 +308,7 @@ function _nondiff_frule_expr(primal_sig_parts, primal_invoke)
         :(=),
         Expr(:call, :(ChainRulesCore.frule), esc(:_), esc.(primal_sig_parts)...),
         # Julia functions always only have 1 output, so just return a single DoesNotExist()
-        Expr(:tuple, primal_invoke, DoesNotExist())
+        Expr(:tuple, primal_invoke, DoesNotExist()),
     )
 end
 
@@ -379,12 +378,12 @@ end
 "turn both `a` and `a::S` into `a`"
 _unconstrain(arg::Symbol) = arg
 function _unconstrain(arg::Expr)
-    Meta.isexpr(arg, :(::), 2) && return arg.args[1]  # dop constraint.
+    Meta.isexpr(arg, :(::), 2) && return arg.args[1]  # drop constraint.
     error("malformed arguments: $arg")
 end
 
-"turn both `a` and `::Number` into `a::Number` into `a::Number` etc"
-function _constrain_and_name(arg::Expr, default_constraint)
+"turn both `a` and `::constraint` into `a::constraint` etc"
+function _constrain_and_name(arg::Expr, _)
     Meta.isexpr(arg, :(::), 2) && return arg  # it is already fine.
     Meta.isexpr(arg, :(::), 1) && return Expr(:(::), gensym(), arg.args[1])  #add name
     error("malformed arguments: $arg")

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -254,7 +254,7 @@ propagator_name(fname::QuoteNode, propname::Symbol) = propagator_name(fname.valu
     @non_differentiable(signature_expression)
 
 A helper to make it easier to declare that a method is not not differentiable.
-This is a short-hand for defining an [`frule`](@ref) and [`rrule`](@ref) that 
+This is a short-hand for defining an [`frule`](@ref) and [`rrule`](@ref) that
 return [`DoesNotExist()`](@ref) for all partials (except for the function `s̄elf`-partial
 itself which is `NO_FIELDS`)
 
@@ -296,7 +296,7 @@ macro non_differentiable(sig_expr)
 
     unconstrained_args = _unconstrain.(constrained_args)
     primal_invoke = Expr(:call, esc(primal_name), esc.(unconstrained_args)...)
-   
+
     quote
         $(_nondiff_frule_expr(primal_sig_parts, primal_invoke))
         $(_nondiff_rrule_expr(primal_sig_parts, primal_invoke))
@@ -330,7 +330,7 @@ end
 
 
 ###########
-# Helpers 
+# Helpers
 
 """
     _isvararg(expr)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -1,0 +1,6 @@
+@testset "rule_definition_tools.jl" begin
+    
+    @testset "@nondifferentiable" begin
+
+    end
+end

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -4,3 +4,8 @@
 
     end
 end
+
+
+Base.remove_linenums!(@macroexpand @non_differentiable println(io::IO))
+
+@non_differentiable println(io::IO)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -9,7 +9,7 @@
             @test pullback(4.5) == (NO_FIELDS, DoesNotExist(), DoesNotExist())
         end
 
-        @testset "nondiff_1_2" begin
+        @testset "one input, 2-tuple output function" begin
             nondiff_1_2(x) = (5.0, 3.0)
             @non_differentiable nondiff_1_2(::Any)
             @test frule((Zero(), 1.2), nondiff_1_2, 3.1) == ((5.0, 3.0), DoesNotExist())

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -1,11 +1,40 @@
 @testset "rule_definition_tools.jl" begin
     
-    @testset "@nondifferentiable" begin
+    @testset "@non_differentiable" begin
+        @testset "nondiff_2_1" begin
+            nondiff_2_1(x, y) = fill(7.5, 100)[x + y]
+            @non_differentiable nondiff_2_1(::Any, ::Any)
+            @test frule((Zero(), 1.2, 2.3), nondiff_2_1, 3, 2) == (7.5, DoesNotExist())
+            res, pullback = rrule(nondiff_2_1, 3, 2)
+            @test res == 7.5
+            @test pullback(4.5) == (NO_FIELDS, DoesNotExist(), DoesNotExist())
+        end
 
+        @testset "nondiff_1_2" begin
+            nondiff_1_2(x) = (5.0, 3.0)
+            @non_differentiable nondiff_1_2(::Any)
+            @test frule((Zero(), 1.2), nondiff_1_2, 3.1) == ((5.0, 3.0), DoesNotExist())
+            res, pullback = rrule(nondiff_1_2, 3.1)
+            @test res == (5.0, 3.0)
+            @test isequal(
+                pullback(Composite{Tuple{Float64, Float64}}(1.2, 3.2)),
+                (NO_FIELDS, DoesNotExist()),
+            )
+        end
+
+        @testset "specific signature" begin
+            nonembed_identity(x) = x
+            @non_differentiable nonembed_identity(::Integer)
+
+            @test frule((Zero(), 1.2), nonembed_identity, 2) == (2, DoesNotExist())
+            @test frule((Zero(), 1.2), nonembed_identity, 2.0) == nothing
+
+            res, pullback = rrule(nonembed_identity, 2)
+            @test res == 2
+            @test pullback(1.2) == (NO_FIELDS, DoesNotExist())
+
+            @test rrule(nonembed_identity, 2.0) == nothing
+        end
     end
 end
 
-
-Base.remove_linenums!(@macroexpand @non_differentiable println(io::IO))
-
-@non_differentiable println(io::IO)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -1,5 +1,5 @@
 """
-Along same lines as  `@test_throws` but to test if a macro throw an exception when it is 
+Along same lines as  `@test_throws` but to test if a macro throw an exception when it is
 expanded.
 """
 macro test_macro_throws(err_expr, expr)
@@ -17,7 +17,7 @@ macro test_macro_throws(err_expr, expr)
             @test_throws $(esc(err_expr)) ($(Meta.quot(expr)); throw(err))
         else
             @test_throws $(esc(err_expr)) $(Meta.quot(expr))
-        end        
+        end
     end
 end
 
@@ -72,7 +72,7 @@ end
 
             @test rrule(pointy_identity, 2.0) == nothing
         end
-        
+
         @testset "Not supported (Yet)" begin
             # Varargs are not supported
             @test_macro_throws ErrorException @non_differentiable vararg1(xs...)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -1,6 +1,6 @@
 @testset "rule_definition_tools.jl" begin
     @testset "@non_differentiable" begin
-        @testset "nondiff_2_1" begin
+        @testset "two input one output function" begin
             nondiff_2_1(x, y) = fill(7.5, 100)[x + y]
             @non_differentiable nondiff_2_1(::Any, ::Any)
             @test frule((Zero(), 1.2, 2.3), nondiff_2_1, 3, 2) == (7.5, DoesNotExist())

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -21,7 +21,7 @@
             )
         end
 
-        @testset "specific signature" begin
+        @testset "constrained signature" begin
             nonembed_identity(x) = x
             @non_differentiable nonembed_identity(::Integer)
 
@@ -62,4 +62,3 @@
 
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using Test
 
     include("ruleset_loading.jl")
     include("rules.jl")
+    include("rule_definition_tools.jl")
 
 
     @testset "demos" begin


### PR DESCRIPTION
Closes #150 

This relies on `DoesNotExist()` iterating to give itself, since we don't knopw how many returns a forward mode rule needs.
Which i thought it did, but maybe we removed that at one point?
Its also useful for use with Composites.