### PR TITLE
include backtrace in error message from on_new_rule hook failure

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/src/ruleset_loading.jl
+++ b/src/ruleset_loading.jl
@@ -136,6 +136,6 @@ function _safe_hook_fun(hook_fun, sig)
     try
         hook_fun(sig)
     catch err
-        @error "Error triggering hook" hook_fun sig exception=err
+        @error "Error triggering hook" hook_fun sig exception=(err, catch_backtrace())
     end
 end


### PR DESCRIPTION
It was annoying trying to find errors in hook functions

before this PR an error might be:
```julia
┌ Error: Error triggering hook
│   hook_fun = generate_overload (generic function with 1 method)
│   sig = Tuple{typeof(hypot),T,T} where T<:Union{Real, Complex}
│   exception =
│    TypeError: in <:, expected Type, got a value of type TypeVar
└ @ ChainRulesCore ~/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:139
```

but after this PR it is
```julia
┌ Error: Error triggering hook
│   hook_fun = generate_overload (generic function with 1 method)
│   sig = Tuple{typeof(hypot),T,T} where T<:Union{Real, Complex}
│   exception =
│    TypeError: in <:, expected Type, got a value of type TypeVar
│    Stacktrace:
│     [1] #66 at ./none:0 [inlined]
│     [2] iterate at ./generator.jl:47 [inlined]
│     [3] _all(::typeof(identity), ::Base.Generator{Base.Iterators.Rest{Core.SimpleVector,Int64},Nabla.var"#66#71"}, ::Colon) at ./reduce.jl:827
│     [4] all at ./reduce.jl:823 [inlined]
│     [5] all(::Base.Generator{Base.Iterators.Rest{Core.SimpleVector,Int64},Nabla.var"#66#71"}) at ./reduce.jl:741
│     [6] generate_overload(::Type{T} where T) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/Nabla.jl/src/sensitivities/chainrules.jl:21
│     [7] _safe_hook_fun(::typeof(Nabla.generate_overload), ::Type{T} where T) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:137
│     [8] (::ChainRulesCore.var"#60#61"{typeof(Nabla.generate_overload),typeof(rrule)})(::Method) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:33
│     [9] iterate at ./generator.jl:47 [inlined]
│     [10] grow_to!(::Array{Union{Nothing, Bool},1}, ::Base.Generator{Base.Generator{Base.Iterators.Filter{ChainRulesCore.var"#62#63",Base.MethodList},typeof(identity)},ChainRulesCore.var"#60#61"{typeof(Nabla.generate_overload),typeof(rrule)}}, ::Int64) at ./array.jl:778
│     [11] grow_to!(::Array{Nothing,1}, ::Base.Generator{Base.Generator{Base.Iterators.Filter{ChainRulesCore.var"#62#63",Base.MethodList},typeof(identity)},ChainRulesCore.var"#60#61"{typeof(Nabla.generate_overload),typeof(rrule)}}, ::Int64) at ./array.jl:776
│     [12] grow_to!(::Array{Union{Nothing, Bool},1}, ::Base.Generator{Base.Generator{Base.Iterators.Filter{ChainRulesCore.var"#62#63",Base.MethodList},typeof(identity)},ChainRulesCore.var"#60#61"{typeof(Nabla.generate_overload),typeof(rrule)}}) at ./array.jl:751
│     [13] collect(::Base.Generator{Base.Generator{Base.Iterators.Filter{ChainRulesCore.var"#62#63",Base.MethodList},typeof(identity)},ChainRulesCore.var"#60#61"{typeof(Nabla.generate_overload),typeof(rrule)}}) at ./array.jl:684
│     [14] map(::Function, ::Base.Generator{Base.Iterators.Filter{ChainRulesCore.var"#62#63",Base.MethodList},typeof(identity)}) at ./abstractarray.jl:2188
│     [15] on_new_rule(::Function, ::Function) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:31
│     [16] top-level scope at REPL[10]:1
│     [17] include_string(::Function, ::Module, ::String, ::String) at ./loading.jl:1088
│     [18] include_string at ./loading.jl:1096 [inlined]
│     [19] repleval(::Module, ::String, ::String) at /Users/oxinabox/.vscode/extensions/julialang.language-julia-1.0.6/scripts/packages/VSCodeServer/src/repl.jl:97
│     [20] evalrepl(::Module, ::String, ::REPL.LineEditREPL, ::REPL.LineEdit.Prompt) at /Users/oxinabox/.vscode/extensions/julialang.language-julia-1.0.6/scripts/packages/VSCodeServer/src/repl.jl:82
│     [21] top-level scope at /Users/oxinabox/.vscode/extensions/julialang.language-julia-1.0.6/scripts/packages/VSCodeServer/src/repl.jl:73
│     [22] eval(::Module, ::Any) at ./boot.jl:331
│     [23] eval_user_input(::Any, ::REPL.REPLBackend) at /usr/local/src/julia/julia-1.5/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:134
│     [24] repl_backend_loop(::REPL.REPLBackend) at /usr/local/src/julia/julia-1.5/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:195
│     [25] start_repl_backend(::REPL.REPLBackend, ::Any) at /usr/local/src/julia/julia-1.5/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:180
│     [26] run_repl(::REPL.AbstractREPL, ::Any; backend_on_current_task::Bool) at /usr/local/src/julia/julia-1.5/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:292
│     [27] run_repl(::REPL.AbstractREPL, ::Any) at /usr/local/src/julia/julia-1.5/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:288
│     [28] (::Base.var"#806#808"{Bool,Bool,Bool,Bool})(::Module) at ./client.jl:399
│     [29] #invokelatest#1 at ./essentials.jl:710 [inlined]
│     [30] invokelatest at ./essentials.jl:709 [inlined]
│     [31] run_main_repl(::Bool, ::Bool, ::Bool, ::Bool, ::Bool) at ./client.jl:383
│     [32] exec_options(::Base.JLOptions) at ./client.jl:313
│     [33] _start() at ./client.jl:506
└ @ ChainRulesCore ~/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:139
```
which is too much information, but I would rather too much than too little.
I guess we could scrub the backrace after it gets up to:
```
│     [7] _safe_hook_fun(::typeof(Nabla.generate_overload), ::Type{T} where T) at /Users/oxinabox/JuliaEnvs/ChainRulesWorld/ChainRulesCore.jl/src/ruleset_loading.jl:137
```
but that isn't easy