### PR TITLE
Add kwarg support to at-nondifferentiable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -73,6 +73,32 @@ end
             @test rrule(pointy_identity, 2.0) == nothing
         end
 
+        @testset "kwargs" begin
+            kw_demo(x; kw=2.0) = x + kw
+            @non_differentiable kw_demo(::Any)
+
+            @testset "not setting kw" begin
+                @assert kw_demo(1.5) == 3.5
+
+                res, pullback = rrule(kw_demo, 1.5)
+                @test res == 3.5
+                @test pullback(4.1) == (NO_FIELDS, DoesNotExist())
+
+                @test frule((Zero(), 11.1), kw_demo, 1.5) == (3.5, DoesNotExist())
+            end
+
+            @testset "setting kw" begin
+                @assert kw_demo(1.5; kw=3.0) == 4.5
+
+                res, pullback = rrule(kw_demo, 1.5; kw=3.0)
+                @test res == 4.5
+                @test pullback(1.1) == (NO_FIELDS, DoesNotExist())
+
+                @test frule((Zero(), 11.1), kw_demo, 1.5; kw=3.0) == (4.5, DoesNotExist())
+            end
+
+        end
+
         @testset "Not supported (Yet)" begin
             # Varargs are not supported
             @test_macro_throws ErrorException @non_differentiable vararg1(xs...)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -96,7 +96,6 @@ end
 
                 @test frule((Zero(), 11.1), kw_demo, 1.5; kw=3.0) == (4.5, DoesNotExist())
             end
-
         end
 
         @testset "Not supported (Yet)" begin


### PR DESCRIPTION
Follow up to #207 
fixes #216 

Following this we just always accept kw-args and then just allways pass them on