### PR TITLE
Remove FiniteDifferences from tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.13"
+version = "0.9.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -129,11 +129,9 @@ _second(t) = Base.tuple_type_head(Base.tuple_type_tail(t))
         Ω = complex_times(x)
         Ω_fwd, Ω̇ = frule((nothing, ẋ), complex_times, x)
         @test Ω_fwd == Ω
-        @test Ω̇ ≈ jvp(central_fdm(5, 1), complex_times, (x, ẋ))
         Ω_rev, back = rrule(complex_times, x)
         @test Ω_rev == Ω
         ∂self, ∂x = back(Ω̄)
         @test ∂self == NO_FIELDS
-        @test ∂x ≈ j′vp(central_fdm(5, 1), complex_times, Ω̄, x)[1]
     end
 end

--- a/test/rules.jl
+++ b/test/rules.jl
@@ -129,9 +129,11 @@ _second(t) = Base.tuple_type_head(Base.tuple_type_tail(t))
         Ω = complex_times(x)
         Ω_fwd, Ω̇ = frule((nothing, ẋ), complex_times, x)
         @test Ω_fwd == Ω
+        @test Ω̇ ≈ (1 + 2im) * ẋ
         Ω_rev, back = rrule(complex_times, x)
         @test Ω_rev == Ω
         ∂self, ∂x = back(Ω̄)
         @test ∂self == NO_FIELDS
+        @test ∂x ≈ (1 - 2im) * Ω̄
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using Base.Broadcast: broadcastable
 using BenchmarkTools
 using ChainRulesCore
 using LinearAlgebra: Diagonal, dot
-using FiniteDifferences
 using StaticArrays
 using Test
 


### PR DESCRIPTION
Removes the tests that depend on FiniteDifferences so it can be dropped, addressing #227.