### PR TITLE
Fix show on InplaceableThunks

### DIFF
--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -121,5 +121,5 @@ unthunk(x::InplaceableThunk) = unthunk(x.val)
 (x::InplaceableThunk)() = unthunk(x)
 
 function Base.show(io::IO, x::InplaceableThunk)
-    println(io, "InplaceableThunk($(repr(x.val)), $(repr(x.add!)))")
+    println(io, "InplaceableThunk($(strip(repr(x.val))), $(strip(repr(x.add!))))")
 end

--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -98,7 +98,7 @@ end
 (x::Thunk)() = x.f()
 @inline unthunk(x::Thunk) = x()
 
-Base.show(io::IO, x::Thunk) = println(io, "Thunk($(repr(x.f)))")
+Base.show(io::IO, x::Thunk) = print(io, "Thunk($(repr(x.f)))")
 
 """
     InplaceableThunk(val::Thunk, add!::Function)
@@ -121,5 +121,5 @@ unthunk(x::InplaceableThunk) = unthunk(x.val)
 (x::InplaceableThunk)() = unthunk(x)
 
 function Base.show(io::IO, x::InplaceableThunk)
-    println(io, "InplaceableThunk($(strip(repr(x.val))), $(strip(repr(x.add!))))")
+    print(io, "InplaceableThunk($(repr(x.val)), $(repr(x.add!)))")
 end


### PR DESCRIPTION
@nickrobinson251  pointed out:
> (not this PR, afaiu): InplaceableThunk prints kinda funny (split over two lines)
> 
>     julia> ithunk
>     InplaceableThunk(Thunk(var"#15#17"())
>     , var"#16#18"())

Because `repr(::Thunk)` hcalls `show(::Thunk)` which calls `println` 
so we need to strip it out before using it in the `show` for `InplaceThunk`.

idk if this is the right fix, or if the problem is that `show(::Thunk)` should just use `print` not `println` ?