### PR TITLE
Replace MuladdMacro with manual application of `muladd`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,11 @@ version = "0.9.24"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BenchmarkTools = "0.5"
 FiniteDifferences = "0.10"
-MuladdMacro = "0.2.1"
 StaticArrays = "0.11, 0.12"
 julia = "1"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -10,10 +10,10 @@ uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 version = "0.5.10"
 
 [[ChainRulesCore]]
-deps = ["LinearAlgebra", "MuladdMacro", "SparseArrays"]
+deps = ["LinearAlgebra", "SparseArrays"]
 path = ".."
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.17"
+version = "0.9.24"
 
 [[Dates]]
 deps = ["Printf"]
@@ -30,19 +30,25 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.3"
 
 [[Documenter]]
-deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "fb1ff838470573adc15c71ba79f8d31328f035da"
+deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "a4875e0763112d6d017126f3944f4133abb342ae"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.25.2"
+version = "0.25.5"
 
 [[DocumenterTools]]
 deps = ["Base64", "DocStringExtensions", "Documenter", "FileWatching", "LibGit2", "Sass"]
-git-tree-sha1 = "6fa30234228d9020cbe31e393e9d183e944845bb"
+git-tree-sha1 = "9b40fd93f54ba5ef9d364981124a8ed389fd634e"
 uuid = "35a29f4d-8980-5a13-9543-d66fff28ecb8"
-version = "0.1.7"
+version = "0.1.9"
 
 [[FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[IOCapture]]
+deps = ["Logging"]
+git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
+uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
+version = "0.1.1"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -75,16 +81,11 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MuladdMacro]]
-git-tree-sha1 = "c6190f9a7fc5d9d5915ab29f2134421b12d24a68"
-uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.2"
-
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
+git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.11"
+version = "1.0.15"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -2,7 +2,6 @@ module ChainRulesCore
 using Base.Broadcast: broadcasted, Broadcasted, broadcastable, materialize, materialize!
 using LinearAlgebra: LinearAlgebra
 using SparseArrays: SparseVector, SparseMatrixCSC
-using MuladdMacro: @muladd
 
 export on_new_rule, refresh_rules  # generation tools
 export frule, rrule  # core function


### PR DESCRIPTION
This PR removes the dependency on the MuladdMacro package and instead explicitly adds `muladd` calls to the constructed expression.

The propagation expression is so "clean" with clearly define multiplications and additions that the `muladd` calls can easily be added manually instead of applying the `@muladd` macro that takes care of many special cases such as subtraction etc.

There is one catch to it: it seems currently the `@muladd` macro is applied to the full expression including the partials and therefore also rewrites the user-provided definitions whereas this manual construction only adds `muladd` calls to the products and sum of partials and input gradients.