### PR TITLE
Invalidation squashing attempts

### DIFF
--- a/.github/InvalidationFlagger.yml
+++ b/.github/InvalidationFlagger.yml
@@ -1,0 +1,33 @@
+name: Invalidations
+on: [push, pull_request]
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@v1
+      with:
+        version: 'nightly'
+    - uses: actions/checkout@v2
+    - uses: julia-actions/julia-buildpkg@latest
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_pr
+
+    - uses: actions/checkout@v2
+      with:
+        ref: 'master'
+    - uses: julia-actions/julia-buildpkg@latest
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_master
+
+    - name: Report invalidation counts
+      run: |
+        echo "Invalidations on master: ${{ steps.invs_master.outputs.total }} (${{ steps.invs_master.outputs.deps }} via deps)"
+        echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)"
+      shell: bash
+    - name: PR doesn't increase number of invalidations
+      run: |
+        if (( ${{ steps.invs_pr.outputs.total }} > ${{ steps.invs_master.outputs.total }} )); then
+            exit 1
+        fi
+      shell: bash


### PR DESCRIPTION
On master SnoopCompile identifies the following invalidations
```
julia> using SnoopCompileCore

julia> invalidations = @snoopr using ChainRulesCore;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
4-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Tuple where var"#s3") in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Base.UUID, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Base.UUID, String}}, ::Any, ::Int64) (0 children)
                 6: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting *(s, comp::Composite) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:138 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Union{Regex, String}, Any} triggered MethodInstance for *(::Any, ::Char, ::Any) (0 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Dict where var"#s3"<:Dict) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)

 inserting *(::Zero, ::Any) in ChainRulesCore at /Users/ian/.julia/packages/ChainRulesCore/cpHLu/src/differential_arithmetic.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.REPLMode.promptf() (0 children)
                 2: signature Tuple{typeof(*), Any, String} triggered MethodInstance for Pkg.API.var"#precompile#195"(::Bool, ::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, ::typeof(Pkg.API.precompile), ::Pkg.Types.Context) (15 children)
                 3: signature Tuple{typeof(*), Any, Char} triggered MethodInstance for *(::Any, ::Char, ::Any) (16 children)
   10 mt_cache
```

Seemingly, the string joining methods are being invalidated which is making some of the Pkg REPL methods recompile including others, so I reduced some of the `Base.:*` definitions from `Any` to `Number`.

With this PR we remove both `*` sources of invalidation:
```
2-element Vector{SnoopCompile.MethodInvalidations}:
 inserting convert(::Type{var"#s4"} where var"#s4"<:Tuple, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Tuple where var"#s3") in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:68 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Tuple{DataType, DataType, DataType}}, Any} triggered MethodInstance for Pair{DataType, Tuple{DataType, DataType, DataType}}(::Any, ::Any) (0 children)
                 2: signature Tuple{typeof(convert), Type{NTuple{8, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{8, DataType}}(::Any, ::Any) (0 children)
                 3: signature Tuple{typeof(convert), Type{NTuple{7, DataType}}, Any} triggered MethodInstance for Pair{DataType, NTuple{7, DataType}}(::Any, ::Any) (0 children)
                 4: signature Tuple{typeof(convert), Type{Tuple{Symbol, Any, Symbol, Symbol}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Symbol, Any, Symbol, Symbol}}, ::Any, ::Int64) (0 children)
                 5: signature Tuple{typeof(convert), Type{Tuple{Base.UUID, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Base.UUID, String}}, ::Any, ::Int64) (0 children)
                 6: signature Tuple{typeof(convert), Type{Tuple{Any, String}}, Any} triggered MethodInstance for setindex!(::Vector{Tuple{Any, String}}, ::Any, ::Int64) (0 children)

 inserting convert(::Type{var"#s4"} where var"#s4"<:Dict, comp::Composite{var"#s3", var"#s2"} where var"#s2"<:Dict where var"#s3"<:Dict) in ChainRulesCore at /Users/ian/.julia/dev/ChainRulesCore/src/differentials/composite.jl:69 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (0 children)
                 2: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                 3: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (18 children)
```
Tests pass locally, but there are many soft `@error` messages.

This definitely needs the review of someone close to the internals of ChainRulesCore etc.

Also cc. @timholy just in case you wanted to review as I'm trying to get the hang of this

