### PR TITLE
make creation of inputs to propagation consistently hyginic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.24"
+version = "0.9.25"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -198,6 +198,8 @@ function scalar_rrule_expr(f, call, setup_stmts, inputs, partials)
     end
 end
 
+# For context on why this is important, see 
+# https://github.com/JuliaDiff/ChainRulesCore.jl/pull/276
 "Declares properly hygenic inputs for propagation expressions"
 _propagator_inputs(n) = [esc(gensym(Symbol(:Δ, i))) for i in 1:n]
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -142,7 +142,7 @@ function scalar_frule_expr(f, call, setup_stmts, inputs, partials)
 
     # Δs is the input to the propagator rule
     # because this is push-forward there is one per input to the function
-    Δs = [esc(Symbol(:Δ, i)) for i in 1:n_inputs]
+    Δs = _propagator_inputs(n_inputs)
     pushforward_returns = map(1:n_outputs) do output_i
         ∂s = partials[output_i].args
         propagation_expr(Δs, ∂s)
@@ -173,7 +173,7 @@ function scalar_rrule_expr(f, call, setup_stmts, inputs, partials)
 
     # Δs is the input to the propagator rule
     # because this is a pull-back there is one per output of function
-    Δs = [Symbol(:Δ, i) for i in 1:n_outputs]
+    Δs = _propagator_inputs(n_outputs)
 
     # 1 partial derivative per input
     pullback_returns = map(1:n_inputs) do input_i
@@ -197,6 +197,9 @@ function scalar_rrule_expr(f, call, setup_stmts, inputs, partials)
         end
     end
 end
+
+"Declares properly hygenic inputs for propagation expressions"
+_propagator_inputs(n) = [esc(gensym(Symbol(:Δ, i))) for i in 1:n]
 
 """
     propagation_expr(Δs, ∂s, _conj = false)


### PR DESCRIPTION
Turns out that we were not escaping the inputs correctly in the pullbacks generated by `@scalar` rule.
And in the case of multi-input functions that actually ended up creating and assigining to a global variable during the input destructuring.
Which must be some edge case of the compiler, as normally it errors if you try to do that.
```julia
julia> module FooMod
       bar((FooMod.x, FooMod.y)) = 1
       @eval FooMod  bar((1,2))
       end
ERROR: cannot assign variables in other modules
Stacktrace:
 [1] setproperty! at ./Base.jl:27 [inlined]
 [2] bar(::Tuple{Int64,Int64}) at ./REPL[11]:2
 [3] top-level scope at none:1
 [4] eval(::Module, ::Any) at ./boot.jl:331
 [5] top-level scope at REPL[11]:3
```

Anyway that in turn was making the `sincos` 's rule in ChainRules.jl type-unstable because it was accessing this global variable.
Testing this is really hard. I could make a regression test for exactly that symptom if you think that is a good idea.z



### Before
```julia
julia> Base.remove_linenums!(@macroexpand @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx )
...
function sincos_pullback((ChainRulesCore.Δ1, ChainRulesCore.Δ2))
    $(Expr(:meta, :inline))
    return (ChainRulesCore.NO_FIELDS, ChainRulesCore.muladd.(ChainRulesCore.conj(-sinx), ChainRulesCore.Δ2, ChainRulesCore.:*.(ChainRulesCore.conj(cosx), ChainRulesCore.Δ1)))
end
...
```

### After
```julia

julia> Base.remove_linenums!(@macroexpand @scalar_rule sincos(x) @setup((sinx, cosx) = Ω) cosx -sinx )
...
function sincos_pullback((var"##Δ1#264", var"##Δ2#265"))
    $(Expr(:meta, :inline))
    return (ChainRulesCore.NO_FIELDS, ChainRulesCore.muladd.(ChainRulesCore.conj(-sinx), var"##Δ2#265", ChainRulesCore.:*.(ChainRulesCore.conj(cosx), var"##Δ1#264")))
end
...
```
