### PR TITLE
Stop at-test_broken allocations on 1.0, and just don't test it

### DIFF
--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -285,12 +285,9 @@ end
 
         @testset "Internals don't allocate a ton" begin
             bk = (; x=1.0, y=2.0)
-            if VERSION >= v"1.5"
-                @test (@ballocated(ChainRulesCore.construct($Foo, $bk))) <= 32
-            else
-                @test_broken (@ballocated(ChainRulesCore.construct($Foo, $bk))) <= 32
-            end
-            # weaker version of the above (which should pass, but make sure not failing too bad)
+            VERSION >= v"1.5" && @test (@ballocated(ChainRulesCore.construct($Foo, $bk))) <= 32
+            
+            # weaker version of the above (which should pass on all versions)
             @test (@ballocated(ChainRulesCore.construct($Foo, $bk))) <= 48
             @test (@ballocated ChainRulesCore.elementwise_add($bk, $bk)) <= 48
         end


### PR DESCRIPTION
For some reason Julia 1.0.5 allocates less on linux than on Mac or Windows.
Which has been making the test that is marked s `@test_broken` actually pass.
Which triggers an Error and makes CI fail.
E.g.
https://github.com/JuliaDiff/ChainRulesCore.jl/pull/272/checks?check_run_id=1688697214

I don't think we care to mark it broken.
We are not going to fix allocations on 1.0 anyway.
And we have tests lower down in that section that do make claims about 1.0 allocations.
