### PR TITLE
Make unpacking a Tuple or NamedTuple Composite type-inferrable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.25"
+version = "0.9.26"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,13 @@ uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 version = "0.9.25"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BenchmarkTools = "0.5"
+Compat = "2, 3"
 FiniteDifferences = "0.10"
 StaticArrays = "0.11, 0.12"
 julia = "1"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -2,6 +2,7 @@ module ChainRulesCore
 using Base.Broadcast: broadcasted, Broadcasted, broadcastable, materialize, materialize!
 using LinearAlgebra: LinearAlgebra
 using SparseArrays: SparseVector, SparseMatrixCSC
+using Compat: hasfield
 
 export on_new_rule, refresh_rules  # generation tools
 export frule, rrule  # core function

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -96,6 +96,10 @@ function Base.reverse(comp::Composite)
     Composite{typeof(rev_backing), typeof(rev_backing)}(rev_backing)
 end
 
+function Base.indexed_iterate(comp::Composite{P,<:Tuple}, i::Int, state=1) where {P}
+    return Base.indexed_iterate(backing(comp), i, state)
+end
+
 function Base.map(f, comp::Composite{P, <:Tuple}) where P
     vals::Tuple = map(f, backing(comp))
     return Composite{P, typeof(vals)}(vals)

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -73,10 +73,16 @@ Base.getindex(comp::Composite, idx) = getindex(backing(comp), idx)
 # for Tuple
 Base.getproperty(comp::Composite, idx::Int) = unthunk(getproperty(backing(comp), idx))
 function Base.getproperty(
-    comp::Composite{P, <:NamedTuple{L}}, idx::Symbol
-) where {P, L}
-    # Need to check L directly, or else this does not constant-fold
-    idx ∈ L || return Zero()
+    comp::Composite{P, T}, idx::Symbol
+) where {P, L, T<:NamedTuple{L}}
+    # hasfield was added in v1.2
+    if VERSION ≥ v"1.2.0-DEV.272"
+        # hasfield more reliably constant-folds than checking L directly
+        hasfield(T, idx) || return Zero()
+    else
+        # Need to check L directly, or else this does not constant-fold
+        idx ∈ L || return Zero()
+    end
     return unthunk(getproperty(backing(comp), idx))
 end
 

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -74,15 +74,8 @@ Base.getindex(comp::Composite, idx) = getindex(backing(comp), idx)
 Base.getproperty(comp::Composite, idx::Int) = unthunk(getproperty(backing(comp), idx))
 function Base.getproperty(
     comp::Composite{P, T}, idx::Symbol
-) where {P, L, T<:NamedTuple{L}}
-    # hasfield was added in v1.2
-    if VERSION ≥ v"1.2.0-DEV.272"
-        # hasfield more reliably constant-folds than checking L directly
-        hasfield(T, idx) || return Zero()
-    else
-        # Need to check L directly, or else this does not constant-fold
-        idx ∈ L || return Zero()
-    end
+) where {P, T<:NamedTuple}
+    hasfield(T, idx) || return Zero()
     return unthunk(getproperty(backing(comp), idx))
 end
 

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -18,6 +18,15 @@ struct StructWithInvariant
     StructWithInvariant(x) = new(x, 2x)
 end
 
+function _unpack2tuple(comp)
+    a, b = comp
+    return (a, b)
+end
+
+function _unpacknamedtuple(comp)
+    x, y = comp.x, comp.y
+    return (x, y)
+end
 
 @testset "Composite" begin
     @testset "empty types" begin
@@ -77,6 +86,17 @@ end
         # Testing iterate via collect
         @test collect(Composite{Foo}(x=2.5)) == [2.5]
         @test collect(Composite{Tuple{Float64,}}(2.0)) == [2.0]
+
+        # Test indexed_iterate
+        ctup = Composite{Tuple{Float64,Int64}}(2.0, 3)
+        @inferred _unpack2tuple(ctup)
+        @test _unpack2tuple(ctup) === (2.0, 3)
+
+        # Test getproperty is inferrable
+        if VERSION ≥ v"1.2"
+            @inferred _unpacknamedtuple(Composite{Foo}(x=2, y=3.0))
+            @inferred _unpacknamedtuple(Composite{Foo}(y=3.0))
+        end
     end
 
     @testset "reverse" begin

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -18,16 +18,6 @@ struct StructWithInvariant
     StructWithInvariant(x) = new(x, 2x)
 end
 
-function _unpack2tuple(comp)
-    a, b = comp
-    return (a, b)
-end
-
-function _unpacknamedtuple(comp)
-    x, y = comp.x, comp.y
-    return (x, y)
-end
-
 @testset "Composite" begin
     @testset "empty types" begin
         @test typeof(Composite{Tuple{}}()) == Composite{Tuple{}, Tuple{}}
@@ -89,10 +79,15 @@ end
 
         # Test indexed_iterate
         ctup = Composite{Tuple{Float64,Int64}}(2.0, 3)
+        _unpack2tuple = function(comp)
+            a, b = comp
+            return (a, b)
+        end
         @inferred _unpack2tuple(ctup)
         @test _unpack2tuple(ctup) === (2.0, 3)
 
         # Test getproperty is inferrable
+        _unpacknamedtuple = comp -> (comp.x, comp.y)
         if VERSION ≥ v"1.2"
             @inferred _unpacknamedtuple(Composite{Foo}(x=2, y=3.0))
             @inferred _unpacknamedtuple(Composite{Foo}(y=3.0))


### PR DESCRIPTION
This PR resolves two issues that make unpacking a `Composite` uninferrable. On Julia 1.5, currently the following operations are uninferrable:

```julia
function foo(x)
    a, b = x
    return (a, b)
end

struct Bar
    a
    b
end

bar(x) = (x.a, x.b)

julia> using LinearAlgebra, ChainRulesCore, Test

julia> x = (3.0, 4); ∂x = Composite{typeof(x)}(5.0, 6);

julia> @inferred foo(∂x)
ERROR: return type Tuple{Float64,Int64} does not match inferred return type Tuple{Union{Float64, Int64},Union{Float64, Int64}}
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at REPL[9]:1

julia> y = Bar(3.0, 4); ∂y = Composite{typeof(y)}(a=5.0, b=6);

julia> @inferred bar(∂y)
ERROR: return type Tuple{Float64,Int64} does not match inferred return type Tuple{Float64,Union{Zero, Int64}}
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at REPL[13]:1
```

These uninferrabilities came up in https://github.com/JuliaDiff/ChainRules.jl/pull/193 and https://github.com/JuliaDiff/ChainRules.jl/pull/323#discussion_r539259034, respectively.

With this PR, these tests now pass.