### PR TITLE
Update badges to show build status and coverage now we use GithubActions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 # ChainRulesCore
 
-[![Travis](https://travis-ci.org/JuliaDiff/ChainRulesCore.jl.svg?branch=master)](https://travis-ci.org/JuliaDiff/ChainRulesCore.jl)
-[![Coveralls](https://coveralls.io/repos/github/JuliaDiff/ChainRulesCore.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaDiff/ChainRulesCore.jl?branch=master)
-[![PkgEval](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/C/ChainRulesCore.svg)](https://juliaci.github.io/NanosoldierReports/pkgeval_badges/report.html)
+[![Build Status](https://github.com/JuliaDiff/ChainRulesCore.jl/workflows/CI/badge.svg)](https://github.com/JuliaDiff/ChainRulesCore.jl/actions?query=workflow:CI)
+[![Coverage](https://codecov.io/gh/JuliaDiff/ChainRulesCore.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaDiff/ChainRulesCore.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 


### PR DESCRIPTION
- noticed these were out of date when reviewing #302 