### PR TITLE
WIP: Sketch project implementation

### DIFF
--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -24,6 +24,7 @@ include("differentials/composite.jl")
 
 include("differential_arithmetic.jl")
 include("accumulation.jl")
+include("projection.jl")
 
 include("rules.jl")
 include("rule_definition_tools.jl")

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -1,0 +1,55 @@
+using LinearAlgebra: Diagonal, diag
+
+"""
+    project(T::Type, x, dx)
+
+"project" `dx` onto type `T` such that it is the same size as `x`.
+
+It's necessary to have `x` to ensure that it's possible to project e.g. `AbstractZero`s
+onto `Array`s -- this wouldn't be possible with type information alone because the neither
+`AbstractZero`s nor `T` know what size of `Array` to produce.
+"""
+function project end
+
+# Number-types
+project(::Type{T}, x::T, dx::T) where {T<:Real} = dx
+
+project(::Type{T}, x::T, dx::AbstractZero) where {T<:Real} = zero(x)
+
+project(::Type{T}, x::T, dx::AbstractThunk) where {T<:Real} = project(x, unthunk(dx))
+
+
+
+# Arrays
+project(::Type{Array{T, N}}, x::Array{T, N}, dx::Array{T, N}) where {T<:Real, N} = dx
+
+project(::Type{<:Array{T}}, x::Array, dx::Array) where {T} = project.(Ref(T), x, dx)
+
+function project(::Type{T}, x::Array, dx::AbstractArray) where {T<:Array}
+    return project(T, x, collect(dx))
+end
+
+function project(::Type{<:Array{T}}, x::Array, dx::AbstractZero) where {T}
+    return project.(Ref(T), x, Ref(dx))
+end
+
+
+
+# Diagonal
+function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::AbstractMatrix) where {V}
+    return Diagonal(project(V, diag(x), diag(dx)))
+end
+
+function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::Composite) where {V}
+    return Diagonal(project(V, diag(x), dx.diag))
+end
+
+function project(::Type{<:Composite}, x::Diagonal, dx::Diagonal)
+    return Composite{typeof(x)}(diag=diag(dx))
+end
+
+
+
+# One use for this functionality is to make it easy to define addition between two different
+# representations of the same tangent. This also makes it clear that the 
+Base.:(+)(x::Composite{<:Diagonal}, y::Diagonal) = x + project(typeof(x), x, y)

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -1,0 +1,3 @@
+@testset "projection" begin
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using Test
     end
 
     include("accumulation.jl")
+    include("projection.jl")
 
     include("ruleset_loading.jl")
     include("rules.jl")


### PR DESCRIPTION
This is a sketch of my proposal in #286, so that we've got something concrete to base our discussions upon.

I'm not sure that `project` is a good name for the function, but I think that it might roughly correspond to a projection the usual sense, so maybe it's fine 🤷 

It's slightly frustrating, but it appears that we'll need to carry around some additional data about the primal / a related tangent to ensure that e.g. size information is available when `project`ing onto an `Array` from an `AbstractZero`. We've seen this before under a different guise with `to_vec`.

You can potentially use this kind of functionality to
1. make rule-implementer's lives easier, by enabling them to convert whatever tangent they get into their preferred type
2. provide helper functionality to e.g. `Flux` to ensure that users get "the types that they expect"
3. implement `+` between different representations of tangents, as shown at the bottom of `src/projection.jl`.

Note: I don't know how much time I'm going to have to do this properly, so if someone wants to pick this up, please feel free!