### PR TITLE
Fix rrule of sum3 example

### DIFF
--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -274,7 +274,7 @@ function ChainRulesCore.rrule(::typeof(sum3), a)
     y = sum3(a)
     function sum3_pullback(ȳ)
         grad = zeros(length(a))
-        grad[1:3] .+= 1.0
+        grad[1:3] .+= ȳ
         return NO_FIELDS, grad
     end
     return y, sum3_pullback


### PR DESCRIPTION
I enjoyed reading this clear doc page! In the end fixed an rrule typo I think, timings and results on the example are left unchanged :+1: 