### PR TITLE
Add qualification

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -361,7 +361,7 @@ function _nondiff_rrule_expr(primal_sig_parts, primal_invoke)
     )
     return esc(quote
         # Manually defined kw version to save compiler work. See explanation in rules.jl
-        function (::Core.kwftype(typeof(rrule)))(kwargs::Any, rrule::typeof(ChainRulesCore.rrule), $(primal_sig_parts...))
+        function (::Core.kwftype(typeof(ChainRulesCore.rrule)))(kwargs::Any, rrule::typeof(ChainRulesCore.rrule), $(primal_sig_parts...))
             return ($(_with_kwargs_expr(primal_invoke)), $pullback_expr)
         end
         function ChainRulesCore.rrule($(primal_sig_parts...))


### PR DESCRIPTION
This PR fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/317 (tested also with DynamicPPL) but IMO it is the wrong fix. Instead one should apply `esc` only locally, wherever needed: currently definitions such as `@non_differentiable Base.length(kwargs::AbstractVector)` or `@non_differentiable Base.length(rrule::AbstractVector)` will lead to multiple arguments of the same name in the `rrule` and `frule` definitions.