### PR TITLE
Use `Base.remove_linenums!` to obtain cleaner macro output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.33"
+version = "0.9.34"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -2,10 +2,7 @@
 using Base.Meta
 
 macro strip_linenos(expr)
-    strip_linenos(x::LineNumberNode) = nothing
-    strip_linenos(x::Expr) = Expr(x.head, map(strip_linenos, x.args)...)
-    strip_linenos(x) = x
-    return esc(strip_linenos(expr))
+    return esc(Base.remove_linenums!(expr))
 end
 
 """


### PR DESCRIPTION
This PR replaces `strip_linenos` (the function, not the macro) with `Base.remove_linenums!`. This leads to cleaner output of the macros, e.g., on master one gets
```julia
julia> @macroexpand @scalar_rule identity(x) 1.0
quote                   
    #= /home/david/.julia/packages/ChainRulesCore/JWrYo/src/rule_definition_tools.jl:94 =#
    if !(identity isa ChainRulesCore.Type) && ChainRulesCore.fieldcount(ChainRulesCore.typeof(identity)) > 0
        #= /home/david/.julia/packages/ChainRulesCore/JWrYo/src/rule_definition_tools.jl:95 =#
        ChainRulesCore.throw(ChainRulesCore.ArgumentError("@scalar_rule cannot be used on closures/functors (such as $(identity))"))
    end
    #= /home/david/.julia/packages/ChainRulesCore/JWrYo/src/rule_definition_tools.jl:100 =#
    begin
        nothing
        function (ChainRulesCore.ChainRulesCore).frule((ChainRulesCore._, var"##Δ1#253"), ::ChainRulesCore.typeof(identity), x::Number)
            nothing
            nothing
            #= REPL[4]:1 =#
            nothing
            Ω = identity(x)
            nothing
            nothing
            nothing
            return (Ω, 1.0var"##Δ1#253")
        end
    end
    #= /home/david/.julia/packages/ChainRulesCore/JWrYo/src/rule_definition_tools.jl:101 =#
    begin
        nothing
        function (ChainRulesCore.ChainRulesCore).rrule(::ChainRulesCore.typeof(identity), x::Number)
            nothing
            nothing
            #= REPL[4]:1 =#
            nothing
            Ω = identity(x)
            nothing
            nothing
            nothing
            return (Ω, begin
                        nothing
                        function identity_pullback(var"##Δ1#254")
                            $(Expr(:meta, :inline))
                            nothing
                            nothing
                            #= REPL[4]:1 =#
                            nothing
                            return (ChainRulesCore.NO_FIELDS, ChainRulesCore.conj(1.0) * var"##Δ1#254")
                        end
                    end)
        end
    end
end
```
whereas this PR yields
```julia
julia> @macroexpand @scalar_rule identity(x) 1.0
quote
    #= /home/david/.julia/dev/ChainRulesCore/src/rule_definition_tools.jl:91 =#
    if !(identity isa ChainRulesCore.Type) && ChainRulesCore.fieldcount(ChainRulesCore.typeof(identity)) > 0
        #= /home/david/.julia/dev/ChainRulesCore/src/rule_definition_tools.jl:92 =#
        ChainRulesCore.throw(ChainRulesCore.ArgumentError("@scalar_rule cannot be used on closures/functors (such as $(identity))"))
    end
    #= /home/david/.julia/dev/ChainRulesCore/src/rule_definition_tools.jl:97 =#
    begin
        function (ChainRulesCore.ChainRulesCore).frule((ChainRulesCore._, var"##Δ1#259"), ::ChainRulesCore.typeof(identity), x::Number)
            #= REPL[14]:1 =#
            Ω = identity(x)
            nothing
            return (Ω, 1.0var"##Δ1#259")
        end
    end
    #= /home/david/.julia/dev/ChainRulesCore/src/rule_definition_tools.jl:98 =#
    begin
        function (ChainRulesCore.ChainRulesCore).rrule(::ChainRulesCore.typeof(identity), x::Number)
            #= REPL[14]:1 =#
            Ω = identity(x)
            nothing
            return (Ω, begin
                        function identity_pullback(var"##Δ1#260")
                            $(Expr(:meta, :inline))
                            #= REPL[14]:1 =#
                            return (ChainRulesCore.NO_FIELDS, ChainRulesCore.conj(1.0) * var"##Δ1#260")                        end
                    end)
        end
    end
end
```
Additionally, `Base.remove_linenums!` removes not only `LineNumberNode`s but also `Expr(:line, ...)`: https://github.com/JuliaLang/julia/blob/5d4eaca0c9fa3d555c79dbacdccb9169fdf64b65/base/expr.jl#L349