### PR TITLE
Pin reverse dependency tests to 1.5

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1]
+        julia-version: [1.5]
         os: [ubuntu-latest]
         package:
           - {user: JuliaDiff, repo: ChainRules.jl}


### PR DESCRIPTION
ChainRules.jl is failing tests in 1.6 because of type inference.
til we get around to fixing that seems best to keep our integration tests running on 1.5