### PR TITLE
Interpolate more in rule helpers and fix escaping of `@non_differentiable`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.34"
+version = "0.9.35"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -374,7 +374,7 @@ function _nondiff_rrule_expr(__source__, primal_sig_parts, primal_invoke)
     @gensym kwargs
     return @strip_linenos quote
         # Manually defined kw version to save compiler work. See explanation in rules.jl
-        function (::Core.kwftype(typeof($rrule)))($(esc(kwargs))::Any, ::typeof($rrule), $(esc_primal_sig_parts...))
+        function (::Core.kwftype(typeof(rrule)))($(esc(kwargs))::Any, ::typeof(rrule), $(esc_primal_sig_parts...))
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), $pullback_expr)
         end
         function ChainRulesCore.rrule($(esc_primal_sig_parts...))

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -339,8 +339,9 @@ end
 
 function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
     @gensym kwargs
+    # `::Any` instead of `_`: https://github.com/JuliaLang/julia/issues/32727
     return @strip_linenos quote
-        function ChainRulesCore.frule(_, $(map(esc, primal_sig_parts)...); $(esc(kwargs))...)
+        function ChainRulesCore.frule(::Any, $(map(esc, primal_sig_parts)...); $(esc(kwargs))...)
             $(__source__)
             # Julia functions always only have 1 output, so return a single DoesNotExist()
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), DoesNotExist())
@@ -356,7 +357,7 @@ function tuple_expression(primal_sig_parts)
     else
         num_primal_inputs = length(primal_sig_parts) - 1 # - vararg
         length_expr = :($num_primal_inputs + length($(esc(_unconstrain(primal_sig_parts[end])))))
-        Expr(:call, :ntuple, Expr(:(->), :_, DoesNotExist()), length_expr)
+        Expr(:call, :ntuple, Expr(:(->), :($(esc(:_))), DoesNotExist()), length_expr)
     end
 end
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -88,8 +88,8 @@ macro scalar_rule(call, maybe_setup, partials...)
     ############################################################################
     # Final return: building the expression to insert in the place of this macro
     code = quote
-        if !($f isa Type) && fieldcount(typeof($f)) > 0
-            throw(ArgumentError(
+        if !($f isa $Type) && $(fieldcount)($(typeof)($f)) > 0
+            $(throw)($(ArgumentError)(
                 "@scalar_rule cannot be used on closures/functors (such as $($f))"
             ))
         end
@@ -156,7 +156,7 @@ function scalar_frule_expr(__source__, f, call, setup_stmts, inputs, partials)
     if n_outputs > 1
         # For forward-mode we return a Composite if output actually a tuple.
         pushforward_returns = Expr(
-            :call, :(ChainRulesCore.Composite{typeof($(esc(:Ω)))}), pushforward_returns...
+            :call, :($(Composite){$(typeof)($(esc(:Ω)))}), pushforward_returns...
         )
     else
         pushforward_returns = first(pushforward_returns)
@@ -165,7 +165,7 @@ function scalar_frule_expr(__source__, f, call, setup_stmts, inputs, partials)
     return @strip_linenos quote
         # _ is the input derivative w.r.t. function internals. since we do not
         # allow closures/functors with @scalar_rule, it is always ignored
-        function ChainRulesCore.frule((_, $(Δs...)), ::typeof($f), $(inputs...))
+        function ($ChainRulesCore.frule)(($(esc(:_)), $(Δs...)), ::$(typeof)($f), $(inputs...))
             $(__source__)
             $(esc(:Ω)) = $call
             $(setup_stmts...)
@@ -193,12 +193,12 @@ function scalar_rrule_expr(__source__, f, call, setup_stmts, inputs, partials)
     pullback = @strip_linenos quote
         @inline function $(esc(propagator_name(f, :pullback)))($pullback_input)
             $(__source__)
-            return (NO_FIELDS, $(pullback_returns...))
+            return ($NO_FIELDS, $(pullback_returns...))
         end
     end
 
     return @strip_linenos quote
-        function ChainRulesCore.rrule(::typeof($f), $(inputs...))
+        function ($ChainRulesCore.rrule)(::$(typeof)($f), $(inputs...))
             $(__source__)
             $(esc(:Ω)) = $call
             $(setup_stmts...)
@@ -223,7 +223,7 @@ function propagation_expr(Δs, ∂s, _conj = false)
     # This is basically Δs ⋅ ∂s
     _∂s = map(∂s) do ∂s_i
         if _conj
-            :(conj($(esc(∂s_i))))
+            :($(conj)($(esc(∂s_i))))
         else
             esc(∂s_i)
         end
@@ -233,11 +233,11 @@ function propagation_expr(Δs, ∂s, _conj = false)
     summed_∂_mul_Δs = if n∂s > 1
         # Explicit multiplication is only performed for the first pair
         # of partial and gradient.
-        init_expr = :((*).($(_∂s[1]), $(Δs[1])))
+        init_expr = :(($(*)).($(_∂s[1]), $(Δs[1])))
 
         # Apply `muladd` iteratively.
         foldl(Iterators.drop(zip(_∂s, Δs), 1); init=init_expr) do ex, (∂s_i, Δs_i)
-            :((muladd).($∂s_i, $Δs_i, $ex))
+            :(($(muladd)).($∂s_i, $Δs_i, $ex))
         end
     else
         # Note: we don't want to do broadcasting with only 1 multiply (no `+`),
@@ -330,53 +330,57 @@ macro non_differentiable(sig_expr)
 end
 
 "changes `f(x,y)` into `f(x,y; kwargs....)`"
-function _with_kwargs_expr(call_expr::Expr)
+function _with_kwargs_expr(call_expr::Expr, kwargs)
     @assert isexpr(call_expr, :call)
     return Expr(
-        :call, call_expr.args[1], Expr(:parameters, :(kwargs...)), call_expr.args[2:end]...
+        :call, call_expr.args[1], Expr(:parameters, :($(kwargs)...)), call_expr.args[2:end]...
     )
 end
 
 function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
-    return esc(@strip_linenos :(
-        function ChainRulesCore.frule($(gensym(:_)), $(primal_sig_parts...); kwargs...)
+    @gensym kwargs
+    return @strip_linenos quote
+        function ($ChainRulesCore.frule)(_, $(map(esc, primal_sig_parts)...); $(esc(kwargs))...)
             $(__source__)
             # Julia functions always only have 1 output, so return a single DoesNotExist()
-            return ($(_with_kwargs_expr(primal_invoke)), DoesNotExist())
+            return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), $(DoesNotExist)())
         end
-    ))
+    end
 end
 
 function tuple_expression(primal_sig_parts)
     has_vararg = _isvararg(primal_sig_parts[end])
     return if !has_vararg
-        num_primal_inputs = length(primal_sig_parts) - 1 # - primal
-        Expr(:tuple, ntuple(_->DoesNotExist(), num_primal_inputs)...)
+        num_primal_inputs = length(primal_sig_parts)
+        Expr(:tuple, ntuple(_ -> :($(DoesNotExist)()), num_primal_inputs)...)
     else
-        num_primal_inputs = length(primal_sig_parts) - 2 # - primal and vararg
-        length_expr = :($(num_primal_inputs) + length($(_unconstrain(primal_sig_parts[end]))))
-        Expr(:call, :ntuple, Expr(:(->), :_, DoesNotExist()), length_expr)
+        num_primal_inputs = length(primal_sig_parts) - 1 # - vararg
+        length_expr = :($(num_primal_inputs) + $(length)($(esc(_unconstrain(primal_sig_parts[end])))))
+        Expr(:call, :ntuple, Expr(:(->), :($(esc(:_))), :($(DoesNotExist)())), length_expr)
     end
 end
 
 function _nondiff_rrule_expr(__source__, primal_sig_parts, primal_invoke)
+    esc_primal_sig_parts = map(esc, primal_sig_parts)
     tup_expr = tuple_expression(primal_sig_parts)
     primal_name = first(primal_invoke.args)
-    pullback_expr = Expr(
-        :function,
-        Expr(:call, propagator_name(primal_name, :pullback), :_),
-        Expr(:tuple, DoesNotExist(), Expr(:(...), tup_expr))
-    )
-    return esc(@strip_linenos quote
+    pullback_expr = @strip_linenos quote
+        function $(esc(propagator_name(primal_name, :pullback)))($(esc(:_)))
+            return $(tup_expr)
+        end
+    end
+
+    @gensym kwargs
+    return @strip_linenos quote
         # Manually defined kw version to save compiler work. See explanation in rules.jl
-        function (::Core.kwftype(typeof(ChainRulesCore.rrule)))(kwargs::Any, rrule::typeof(ChainRulesCore.rrule), $(primal_sig_parts...))
-            return ($(_with_kwargs_expr(primal_invoke)), $pullback_expr)
+        function (::$(Core.kwftype)($(typeof)($(rrule))))($(esc(kwargs))::$(Any), ::$(typeof)($(rrule)), $(esc_primal_sig_parts...))
+            return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), $(pullback_expr))
         end
-        function ChainRulesCore.rrule($(primal_sig_parts...))
+        function ($ChainRulesCore.rrule)($(esc_primal_sig_parts...))
             $(__source__)
-            return ($primal_invoke, $pullback_expr)
+            return ($(esc(primal_invoke)), $(pullback_expr))
         end
-    end)
+    end
 end
 
 

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -254,21 +254,54 @@ end
 
 
 module IsolatedModuleForTestingScoping
-    using Test
-    # need to make sure macros work in something that hasn't imported all exports
-    # all that matters is that the following don't error, since they will resolve at
-    # parse time
-    using ChainRulesCore: ChainRulesCore
+using ChainRulesCore: @scalar_rule, @non_differentiable
 
-    @testset "@non_differentiable" begin
-        # this is
-        # https://github.com/JuliaDiff/ChainRulesCore.jl/issues/317
-        fixed(x) = :abc
-        ChainRulesCore.@non_differentiable fixed(x)
+# ensure that functions, types etc. in module `ChainRulesCore` can't be resolved
+const ChainRulesCore = nothing
+
+# this is
+# https://github.com/JuliaDiff/ChainRulesCore.jl/issues/317
+fixed(x) = :abc
+@non_differentiable fixed(x)
+
+# check name collision
+fixed_kwargs(x; kwargs...) = :abc
+@non_differentiable fixed_kwargs(kwargs)
+
+my_id(x) = x
+@scalar_rule(my_id(x), 1.0)
+
+module IsolatedSubmodule
+using Test
+using ChainRulesCore: frule, rrule, Zero, DoesNotExist
+using ..IsolatedModuleForTestingScoping: fixed, fixed_kwargs, my_id
+
+@testset "@non_differentiable" begin
+    for f in (fixed, fixed_kwargs)
+        y, ẏ = frule((Zero(), randn()), f, randn())
+        @test y === :abc
+        @test ẏ === DoesNotExist()
+
+        y, f_pullback = rrule(f, randn())
+        @test y === :abc
+        @test f_pullback(randn()) === (DoesNotExist(), DoesNotExist())
     end
 
-    @testset "@scalar_rule" begin
-        my_id(x) = x
-        ChainRulesCore.@scalar_rule(my_id(x), 1.0)
-    end
+    y, f_pullback = rrule(fixed_kwargs, randn(); keyword=randn())
+    @test y === :abc
+    @test f_pullback(randn()) === (DoesNotExist(), DoesNotExist())
+end
+
+@testset "@scalar_rule" begin
+    x, ẋ = randn(2)
+    y, ẏ = frule((Zero(), ẋ), my_id, x)
+    @test y == x
+    @test ẏ == ẋ
+
+    Δy = randn()
+    y, f_pullback = rrule(my_id, x)
+    @test y == x
+    @test f_pullback(Δy) == (Zero(), Δy)
+end
+end
 end

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -254,6 +254,7 @@ end
 
 
 module IsolatedModuleForTestingScoping
+    # check that rules can be defined by macros without any additional imports
     using ChainRulesCore: @scalar_rule, @non_differentiable
 
     # ensure that functions, types etc. in module `ChainRulesCore` can't be resolved
@@ -273,9 +274,11 @@ module IsolatedModuleForTestingScoping
     @scalar_rule(my_id(x), 1.0)
 
     module IsolatedSubmodule
-        using Test
+        # check that rules defined in isolated module without imports can be called
+        # without errors
         using ChainRulesCore: frule, rrule, Zero, DoesNotExist
         using ..IsolatedModuleForTestingScoping: fixed, fixed_kwargs, my_id
+        using Test
 
         @testset "@non_differentiable" begin
             for f in (fixed, fixed_kwargs)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -264,7 +264,8 @@ module IsolatedModuleForTestingScoping
     fixed(x) = :abc
     @non_differentiable fixed(x)
 
-    # check name collision
+    # check name collision between a primal input called `kwargs` and the actual keyword
+    # arguments
     fixed_kwargs(x; kwargs...) = :abc
     @non_differentiable fixed_kwargs(kwargs)
 


### PR DESCRIPTION
The PR interpolates ~~all types and functions that are not provided by the user~~ more types and functions in the AST in the macros `@scalar_rule` and `@non_differentiable`. This fixes the following bug:

```julia
julia> using ChainRulesCore: @non_differentiable

julia> @non_differentiable length(x::AbstractVector)
ERROR: UndefVarError: ChainRulesCore not defined
Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/ChainRulesCore/ASgvC/src/rule_definition_tools.jl:327
```

Additionally, not the whole output of `@non_differentiable` is escaped anymore, fixing a possible name collision for arguments of name `kwargs`:
```julia
julia> using ChainRulesCore: ChainRulesCore, @non_differentiable

julia> @non_differentiable length(kwargs::AbstractVector)
ERROR: syntax: function argument name not unique: "kwargs" around /home/david/.julia/packages/ChainRulesCore/ASgvC/src/rule_definition_tools.jl:327
Stacktrace:
 [1] top-level scope
   @ REPL[17]:1
```

Macro output on the master branch:
```julia
julia> Base.remove_linenums!(@macroexpand @scalar_rule sincos(x) cos(x) -sin(x))
quote
    if !(sincos isa ChainRulesCore.Type) && ChainRulesCore.fieldcount(ChainRulesCore.typeof(sincos)) > 0
        ChainRulesCore.throw(ChainRulesCore.ArgumentError("@scalar_rule cannot be used on closures/functors (such as $(sincos))"))
    end
    begin
        function (ChainRulesCore.ChainRulesCore).frule((ChainRulesCore._, var"##Δ1#257"), ::ChainRulesCore.typeof(sincos), x::Number)
            Ω = sincos(x)
            nothing
            return (Ω, (ChainRulesCore.ChainRulesCore).Composite{ChainRulesCore.typeof(Ω)}(cos(x) * var"##Δ1#257", -(sin(x)) * var"##Δ1#257"))
        end
    end
    begin
        function (ChainRulesCore.ChainRulesCore).rrule(::ChainRulesCore.typeof(sincos), x::Number)
            Ω = sincos(x)
            nothing
            return (Ω, begin
                        function sincos_pullback((var"##Δ1#258", var"##Δ2#259"))
                            $(Expr(:meta, :inline))
                            return (ChainRulesCore.NO_FIELDS, ChainRulesCore.muladd.(ChainRulesCore.conj(-(sin(x))), var"##Δ2#259", ChainRulesCore.:*.(ChainRulesCore.conj(cos(x)), var"##Δ1#258")))
                        end
                    end)
        end
    end
end

julia> Base.remove_linenums!(@macroexpand @non_differentiable length(x::Vector))
quote
    function ChainRulesCore.frule(var"##_#260", ::Core.Typeof(length), x::Vector; kwargs...)
        return (length(x; kwargs...), DoesNotExist())
    end
    begin
        function (::Core.kwftype(typeof(ChainRulesCore.rrule)))(kwargs::Any, rrule::typeof(ChainRulesCore.rrule), ::Core.Typeof(length), x::Vector)
            return (length(x; kwargs...), function length_pullback(_)
                        (ChainRulesCore.DoesNotExist(), (ChainRulesCore.DoesNotExist(),)...)
                    end)
        end
        function ChainRulesCore.rrule(::Core.Typeof(length), x::Vector)
            return (length(x), function length_pullback(_)
                        (ChainRulesCore.DoesNotExist(), (ChainRulesCore.DoesNotExist(),)...)
                    end)
        end
    end
end

julia> Base.remove_linenums!(@macroexpand @non_differentiable length(x::Vector...))
quote
    function ChainRulesCore.frule(var"##_#261", ::Core.Typeof(length), x::Vector...; kwargs...)
        return (length(x...; kwargs...), DoesNotExist())
    end
    begin
        function (::Core.kwftype(typeof(ChainRulesCore.rrule)))(kwargs::Any, rrule::typeof(ChainRulesCore.rrule), ::Core.Typeof(length), x::Vector...)
            return (length(x...; kwargs...), function length_pullback(_)
                        (ChainRulesCore.DoesNotExist(), ntuple((_->ChainRulesCore.DoesNotExist()), 0 + length(x))...)
                    end)
        end
        function ChainRulesCore.rrule(::Core.Typeof(length), x::Vector...)
            return (length(x...), function length_pullback(_)
                        (ChainRulesCore.DoesNotExist(), ntuple((_->ChainRulesCore.DoesNotExist()), 0 + length(x))...)
                    end)
        end
    end
end
```

Macro output with this PR:
```julia
julia> Base.remove_linenums!(@macroexpand @scalar_rule sincos(x) cos(x) -sin(x))
quote
    if !(sincos isa ChainRulesCore.Type) && ChainRulesCore.fieldcount(ChainRulesCore.typeof(sincos)) > 0
        ChainRulesCore.throw(ChainRulesCore.ArgumentError("@scalar_rule cannot be used on closures/functors (such as $(sincos))"))
    end
    begin
        function (ChainRulesCore.ChainRulesCore).frule((ChainRulesCore._, var"##Δ1#277"), ::ChainRulesCore.typeof(sincos), x::Number)
            Ω = sincos(x)
            nothing
            return (Ω, ChainRulesCore.Composite{ChainRulesCore.typeof(Ω)}(cos(x) * var"##Δ1#277", -(sin(x)) * var"##Δ1#277"))
        end
    end
    begin
        function (ChainRulesCore.ChainRulesCore).rrule(::ChainRulesCore.typeof(sincos), x::Number)
            Ω = sincos(x)
            nothing
            return (Ω, begin
                        function sincos_pullback((var"##Δ1#278", var"##Δ2#279"))
                            $(Expr(:meta, :inline))
                            return (ChainRulesCore.NO_FIELDS, ChainRulesCore.muladd.(ChainRulesCore.conj(-(sin(x))), var"##Δ2#279", ChainRulesCore.:*.(ChainRulesCore.conj(cos(x)), var"##Δ1#278")))
                        end
                    end)
        end
    end
end

julia> Base.remove_linenums!(@macroexpand @non_differentiable length(x::Vector))
quote
    begin
        function (ChainRulesCore.ChainRulesCore).frule(::ChainRulesCore.Any, ::(Core).Typeof(length), x::Vector; var"##kwargs#280"...)
            return (length(x; var"##kwargs#280"...), ChainRulesCore.DoesNotExist())
        end
    end
    begin
        function (::(ChainRulesCore.Core).kwftype(ChainRulesCore.typeof(ChainRulesCore.rrule)))(var"##kwargs#281"::ChainRulesCore.Any, ::ChainRulesCore.typeof(ChainRulesCore.rrule
), ::(Core).Typeof(length), x::Vector)
            return (length(x; var"##kwargs#281"...), begin
                        function length_pullback(::ChainRulesCore.Any)
                            return (ChainRulesCore.DoesNotExist(), ChainRulesCore.DoesNotExist())
                        end
                    end)
        end
        function (ChainRulesCore.ChainRulesCore).rrule(::(Core).Typeof(length), x::Vector)
            return (length(x), begin
                        function length_pullback(::ChainRulesCore.Any)
                            return (ChainRulesCore.DoesNotExist(), ChainRulesCore.DoesNotExist())
                        end
                    end)
        end
    end
end

julia> Base.remove_linenums!(@macroexpand @non_differentiable length(x::Vector...))
quote
    begin
        function (ChainRulesCore.ChainRulesCore).frule(::ChainRulesCore.Any, ::(Core).Typeof(length), x::Vector...; var"##kwargs#282"...)
            return (length(x...; var"##kwargs#282"...), ChainRulesCore.DoesNotExist())
        end
    end
    begin
        function (::(ChainRulesCore.Core).kwftype(ChainRulesCore.typeof(ChainRulesCore.rrule)))(var"##kwargs#283"::ChainRulesCore.Any, ::ChainRulesCore.typeof(ChainRulesCore.rrule
), ::(Core).Typeof(length), x::Vector...)
            return (length(x...; var"##kwargs#283"...), begin
                        function length_pullback(::ChainRulesCore.Any)
                            return ChainRulesCore.ntuple(((::ChainRulesCore.Any,)->begin
                                            ChainRulesCore.DoesNotExist()
                                        end), 1 + ChainRulesCore.length(x))
                        end
                    end)
        end
        function (ChainRulesCore.ChainRulesCore).rrule(::(Core).Typeof(length), x::Vector...)
            return (length(x...), begin
                        function length_pullback(::ChainRulesCore.Any)
                            return ChainRulesCore.ntuple(((::ChainRulesCore.Any,)->begin
                                            ChainRulesCore.DoesNotExist()
                                        end), 1 + ChainRulesCore.length(x))
                        end
                    end)
        end
    end
end
```

This fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/320.

**Edit:** Updated after the suggestions by the reviewers were incorporated.