### PR TITLE
Mark discarded arguments with `@nospecialize`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.35"
+version = "0.9.36"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Contains the changes suggested in https://github.com/JuliaDiff/ChainRulesCore.jl/pull/325#issuecomment-811278617: Discarded arguments in the rules generated by `@non_differentiable` are marked with `@nospecialize`.