### PR TITLE
Fix error of `@non_differentiable` on Julia 1.5.0 and 1.5.1 (#328)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.36"
+version = "0.9.37"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -359,7 +359,7 @@ function tuple_expression(primal_sig_parts)
     else
         num_primal_inputs = length(primal_sig_parts) - 1 # - vararg
         length_expr = :($num_primal_inputs + length($(esc(_unconstrain(primal_sig_parts[end])))))
-        @strip_linenos :(ntuple(::Any -> DoesNotExist(), $length_expr))
+        @strip_linenos :(ntuple(i -> DoesNotExist(), $length_expr))
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/328.

The underlying problem is https://github.com/JuliaLang/julia/issues/37134 which exists on Julia 1.5.0 and 1.5.1, and was fixed in Julia 1.5.2 (https://github.com/JuliaLang/julia/pull/37181).

I did not add any tests since the error is reproducible only with these Julia versions which currently are not tested on Github.