### PR TITLE
Add `@not_implemented`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.37"
+version = "0.9.38"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -23,6 +23,7 @@ Pages = [
     "differentials/composite.jl",
     "differentials/thunks.jl",
     "differentials/abstract_differential.jl",
+    "differentials/notimplemented.jl",
 ]
 Private = false
 ```

--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -53,7 +53,7 @@ https://github.com/JuliaMath/SpecialFunctions.jl/issues/160
 )
 ```
 
-Do not use `@not_implemented` if the differential does not exist mathematically.
+Do not use `@not_implemented` if the differential does not exist mathematically (use `DoesNotExist()` instead).
 
 ## Code Style
 

--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -41,7 +41,7 @@ Examples being:
 One can use [`@not_implemented`](@ref) to mark missing differentials.
 This is helpful if the function has multiple inputs or outputs, and one has worked out analytically and implemented some but not all differentials.
 
-It is recommended to provide additional debugging information such as a link to a GitHub issue about the missing differential:
+It is recommended to include a link to a GitHub issue about the missing differential in the debugging information:
 ```julia
 @not_implemented(
 """

--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -38,12 +38,10 @@ Examples being:
 
 ## Use `@not_implemented` appropriately
 
-One can use [`@not_implemented`](@ref) to mark missing differentials. This is helpful if
-the function has multiple inputs or outputs, and one has worked out analytically and
-implemented some but not all differentials.
+One can use [`@not_implemented`](@ref) to mark missing differentials.
+This is helpful if the function has multiple inputs or outputs, and one has worked out analytically and implemented some but not all differentials.
 
-It is recommended to provide additional debugging information such as a link to a GitHub
-issue about the missing differential:
+It is recommended to provide additional debugging information such as a link to a GitHub issue about the missing differential:
 ```julia
 @not_implemented(
 """

--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -36,6 +36,25 @@ Examples being:
 - There is only one derivative being returned, so from the fact that the user called
   `frule`/`rrule` they clearly will want to use that one.
 
+## Use `@not_implemented` appropriately
+
+One can use [`@not_implemented`](@ref) to mark missing differentials. This is helpful if
+the function has multiple inputs or outputs, and one has worked out analytically and
+implemented some but not all differentials.
+
+It is recommended to provide additional debugging information such as a link to a GitHub
+issue about the missing differential:
+```julia
+@not_implemented(
+"""
+derivatives of Bessel functions with respect to the order are not implemented:
+https://github.com/JuliaMath/SpecialFunctions.jl/issues/160
+"""
+)
+```
+
+Do not use `@not_implemented` if the differential does not exist mathematically.
+
 ## Code Style
 
 Use named local functions for the `pullback` in an `rrule`.

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -6,7 +6,7 @@ using Compat: hasfield
 
 export on_new_rule, refresh_rules  # generation tools
 export frule, rrule  # core function
-export @non_differentiable, @scalar_rule, @thunk  # definition helper macros
+export @non_differentiable, @scalar_rule, @thunk, @not_implemented  # definition helper macros
 export canonicalize, extern, unthunk  # differential operations
 export add!!  # gradient accumulation operations
 # differentials
@@ -21,6 +21,7 @@ include("differentials/abstract_zero.jl")
 include("differentials/one.jl")
 include("differentials/thunks.jl")
 include("differentials/composite.jl")
+include("differentials/notimplemented.jl")
 
 include("differential_arithmetic.jl")
 include("accumulation.jl")

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -42,26 +42,27 @@ Base.muladd(::NotImplemented, ::Zero, z) = z
 Base.muladd(x::NotImplemented, y, ::Zero) = x
 Base.muladd(::NotImplemented, ::Zero, ::Zero) = Zero()
 
-Base.muladd(x::NotImplemented, ::NotImplemented, z) = x
-Base.muladd(x::NotImplemented, ::NotImplemented, ::Zero) = x
-
-Base.muladd(x::NotImplemented, y, ::NotImplemented) = x
-Base.muladd(::NotImplemented, ::Zero, z::NotImplemented) = z
-
 Base.muladd(x, y::NotImplemented, z) = y
 Base.muladd(::Zero, ::NotImplemented, z) = z
 Base.muladd(x, y::NotImplemented, ::Zero) = y
 Base.muladd(::Zero, ::NotImplemented, ::Zero) = Zero()
-
-Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
-Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
 
 Base.muladd(x, y, z::NotImplemented) = z
 Base.muladd(::Zero, y, z::NotImplemented) = z
 Base.muladd(x, ::Zero, z::NotImplemented) = z
 Base.muladd(::Zero, ::Zero, z::NotImplemented) = z
 
+Base.muladd(x::NotImplemented, ::NotImplemented, z) = x
+Base.muladd(x::NotImplemented, ::NotImplemented, ::Zero) = x
+
+Base.muladd(x::NotImplemented, y, ::NotImplemented) = x
+Base.muladd(::NotImplemented, ::Zero, z::NotImplemented) = z
+
+Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
+Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
+
 Base.muladd(x::NotImplemented, ::NotImplemented, ::NotImplemented) = x
+
 # similar to `DoesNotExist`, `Zero` wins `*` and `NotImplemented` wins `+`
 Base.:+(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
 Base.:+(::Zero, x::NotImplemented) = throw(NotImplementedException(x))

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -56,6 +56,11 @@ Base.muladd(::Zero, ::NotImplemented, ::Zero) = Zero()
 Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
 Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
 
+Base.muladd(x, y, z::NotImplemented) = z
+Base.muladd(::Zero, y, z::NotImplemented) = z
+Base.muladd(x, ::Zero, z::NotImplemented) = z
+Base.muladd(::Zero, ::Zero, z::NotImplemented) = z
+
 # similar to `DoesNotExist`, `Zero` wins `*` and `NotImplemented` wins `+`
 Base.:+(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
 Base.:+(::Zero, x::NotImplemented) = throw(NotImplementedException(x))

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -61,6 +61,7 @@ Base.muladd(::Zero, y, z::NotImplemented) = z
 Base.muladd(x, ::Zero, z::NotImplemented) = z
 Base.muladd(::Zero, ::Zero, z::NotImplemented) = z
 
+Base.muladd(x::NotImplemented, ::NotImplemented, ::NotImplemented) = x
 # similar to `DoesNotExist`, `Zero` wins `*` and `NotImplemented` wins `+`
 Base.:+(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
 Base.:+(::Zero, x::NotImplemented) = throw(NotImplementedException(x))

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -8,11 +8,63 @@ Thus we can avoid any ambiguities.
 
 Notice:
     The precedence goes:
-    `DoesNotExist, Zero, One, AbstractThunk, Composite, Any`
+    `NotImplemented, DoesNotExist, Zero, One, AbstractThunk, Composite, Any`
     Thus each of the @eval loops create most definitions of + and *
     defines the combination this type with all types of  lower precidence.
     This means each eval loops is 1 item smaller than the previous.
 ==#
+Base.:+(x::NotImplemented) = throw(NotImplementedException(x))
+Base.:+(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented) = throw(NotImplementedException(x))
+Base.:*(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+function LinearAlgebra.dot(x::NotImplemented, ::NotImplemented)
+    return throw(NotImplementedException(x))
+end
+for T in (:DoesNotExist, :One, :AbstractThunk, :Composite, :Any)
+    @eval Base.:+(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
+    @eval Base.:+(::$T, x::NotImplemented) = throw(NotImplementedException(x))
+    @eval Base.:-(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
+    @eval Base.:-(::$T, x::NotImplemented) = throw(NotImplementedException(x))
+
+    @eval Base.:*(::$T, x::NotImplemented) = throw(NotImplementedException(x))
+
+    @eval LinearAlgebra.dot(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
+    @eval LinearAlgebra.dot(::$T, x::NotImplemented) = throw(NotImplementedException(x))
+
+    # required for `@scalar_rule`
+    @eval Base.:*(x::NotImplemented, ::$T) = x
+end
+
+# required for `@scalar_rule`
+Base.muladd(x::NotImplemented, y, z) = x
+Base.muladd(::NotImplemented, ::Zero, z) = z
+Base.muladd(x::NotImplemented, y, ::Zero) = x
+Base.muladd(::NotImplemented, ::Zero, ::Zero) = Zero()
+
+Base.muladd(x::NotImplemented, ::NotImplemented, z) = x
+Base.muladd(x::NotImplemented, ::NotImplemented, ::Zero) = x
+
+Base.muladd(x::NotImplemented, y, ::NotImplemented) = x
+Base.muladd(::NotImplemented, ::Zero, z::NotImplemented) = z
+
+Base.muladd(x, y::NotImplemented, z) = y
+Base.muladd(::Zero, ::NotImplemented, z) = z
+Base.muladd(x, y::NotImplemented, ::Zero) = y
+Base.muladd(::Zero, ::NotImplemented, ::Zero) = Zero()
+
+Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
+Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
+
+# similar to `DoesNotExist`, `Zero` wins `*` and `NotImplemented` wins `+`
+Base.:+(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
+Base.:+(::Zero, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
+Base.:-(::Zero, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:*(::NotImplemented, ::Zero) = Zero()
+Base.:*(::Zero, ::NotImplemented) = Zero()
+LinearAlgebra.dot(::NotImplemented, ::Zero) = Zero()
+LinearAlgebra.dot(::Zero, ::NotImplemented) = Zero()
 
 Base.:+(::DoesNotExist, ::DoesNotExist) = DoesNotExist()
 Base.:-(::DoesNotExist, ::DoesNotExist) = DoesNotExist()

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -20,6 +20,7 @@ Base.:+(x::NotImplemented) = _error(x)
 Base.:*(x::NotImplemented, ::Any) = x
 
 Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
+Base.convert(::Type{<:Number}, x::NotImplemented) = _error(x)
 
 _error(::NotImplemented) = error("differential not implemented")
 function _error(x::NotImplemented{Module,LineNumberNode})

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -54,7 +54,7 @@ Optionally, one can provide additional information about the missing differentia
     differential as additional debugging information.
 """
 macro not_implemented(info=nothing)
-    :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
+    return :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
 end
 
 struct NotImplementedException{M,S,I} <: Exception

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -2,6 +2,8 @@
     NotImplemented
 
 This differential indicates that the derivative is not implemented.
+It is generally best to construct this using the [`@not_implemented`](@ref) macro,
+which will automatically insert the source module and file location.
 """
 struct NotImplemented{M,S,I} <: AbstractDifferential
     mod::M

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -33,7 +33,7 @@ Base.convert(::Type{<:Number}, x::NotImplemented) = _error(x)
 
 _error(::NotImplemented) = error("differential not implemented")
 function _error(x::NotImplemented{Module,LineNumberNode})
-    error(
+    return error(
         "differential not implemented @ ",
         x.mod,
         " ",

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -1,14 +1,35 @@
 """
+    @not_implemented(info)
+
+Create a differential that indicates that the derivative is not implemented.
+
+The `info` should be useful information about the missing differential for debugging.
+
+!!! note
+    This macro should be used only if the automatic differentiation would error
+    otherwise. It is mostly useful if the function has multiple inputs or outputs,
+    and one has worked out analytically and implemented some but not all differentials.
+
+!!! note
+    It is good practice to include a link to a GitHub issue about the missing
+    differential in the debugging information.
+"""
+macro not_implemented(info)
+    return :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
+end
+
+"""
     NotImplemented
 
 This differential indicates that the derivative is not implemented.
+
 It is generally best to construct this using the [`@not_implemented`](@ref) macro,
 which will automatically insert the source module and file location.
 """
-struct NotImplemented{M,S,I} <: AbstractDifferential
-    mod::M
-    source::S
-    info::I
+struct NotImplemented <: AbstractDifferential
+    mod::Module
+    source::LineNumberNode
+    info::String
 end
 
 # required for `@scalar_rule`
@@ -25,7 +46,9 @@ Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))
 Base.:/(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
 Base.zero(x::NotImplemented) = throw(NotImplementedException(x))
-Base.zero(::Type{<:NotImplemented}) = throw(NotImplementedException())
+Base.zero(::Type{<:NotImplemented}) = throw(NotImplementedException(@not_implemented(
+    "`zero` is not defined for missing differentials of type `NotImplemented`"
+)))
 
 Base.iterate(x::NotImplemented) = throw(NotImplementedException(x))
 Base.iterate(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
@@ -39,41 +62,17 @@ function Base.show(io::IO, x::NotImplemented)
     return print(io, "NotImplemented(", x.mod, ", ", x.source, ", ", x.info, ")")
 end
 
-"""
-    @not_implemented(info=nothing)
-
-Create a differential that indicates that the derivative is not implemented.
-
-Optionally, one can provide additional information about the missing differential.
-
-!!! note
-    This macro should be used only if the automatic differentiation would error
-    otherwise. It is mostly useful if the function has multiple inputs or outputs,
-    and one has worked out analytically and implemented some but not all differentials.
-
-!!! note
-    It is good practice to provide a link to a GitHub issue about the missing
-    differential as additional debugging information.
-"""
-macro not_implemented(info=nothing)
-    return :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
+struct NotImplementedException <: Exception
+    mod::Module
+    source::LineNumberNode
+    info::String
 end
 
-struct NotImplementedException{M,S,I} <: Exception
-    mod::M
-    source::S
-    info::I
-end
-
-NotImplementedException() = NotImplementedException(nothing, nothing, nothing)
 function NotImplementedException(x::NotImplemented)
     return NotImplementedException(x.mod, x.source, x.info)
 end
 
 function Base.showerror(io::IO, e::NotImplementedException)
-    return print(io, "differential not implemented")
-end
-function Base.showerror(io::IO, e::NotImplementedException{Module,LineNumberNode})
     print(io, "differential not implemented @ ", e.mod, " ", e.source)
     if e.info !== nothing
         print(io, "\nInfo: ", e.info)

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -58,12 +58,12 @@ Optionally, one can provide additional information about the missing differentia
 Debugging information is only tracked and displayed if `ChainRulesCore.debug_mode()`
 returns `true`.
 
-!!! note:
+!!! note
     This macro should be used only if the automatic differentiation would error
     otherwise. It is mostly useful if the function has multiple inputs and one
     has worked out analytically differentials of some but not all of them.
 
-!!! note:
+!!! note
     It is good practice to provide a link to a Github issue about the missing
     differential as additional debugging information.
 """

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -38,6 +38,9 @@ Base.:/(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))
 Base.:/(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
+Base.zero(x::NotImplemented) = throw(NotImplementedException(x))
+Base.zero(::Type{<:NotImplemented}) = zero(NotImplemented())
+
 Base.iterate(x::NotImplemented) = throw(NotImplementedException(x))
 Base.iterate(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -16,10 +16,19 @@ extern(x::NotImplemented) = _error(x)
 Base.iterate(x::NotImplemented) = _error(x)
 Base.iterate(x::NotImplemented, ::Any) = _error(x)
 
-Base.:+(x::NotImplemented) = _error(x)
+Base.:+(x::NotImplemented, ::Any) = x
+Base.:+(::Any, x::NotImplemented) = x
+Base.:+(x::NotImplemented, ::NotImplemented) = x
 Base.:*(x::NotImplemented, ::Any) = x
+Base.:*(::Any, x::NotImplemented) = x
+Base.:*(x::NotImplemented, ::NotImplemented) = x
+
+# Linear operators
+Base.adjoint(x::NotImplemented) = x
+Base.transpose(x::NotImplemented) = x
 
 Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
+
 Base.convert(::Type{<:Number}, x::NotImplemented) = _error(x)
 
 _error(::NotImplemented) = error("differential not implemented")

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -9,6 +9,8 @@ struct NotImplemented{M,S,I} <: AbstractDifferential
     info::I
 end
 
+NotImplemented() = NotImplemented(nothing, nothing, nothing)
+
 extern(x::NotImplemented) = _error(x)
 
 Base.iterate(x::NotImplemented) = _error(x)
@@ -39,11 +41,10 @@ Optionally, you can provide additional information such as a Github issue
 about the missing differential. Debugging information is only tracked and
 displayed if `ChainRulesCore.debug_mode()` returns `true`.
 """
-macro not_implemented(_info=nothing)
-    mod, source, info = if debug_mode()
-        __module__, QuoteNode(__source__), _info
+macro not_implemented(info=nothing)
+    return if debug_mode()
+        :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
     else
-        nothing, nothing, nothing
+        :(NotImplemented())
     end
-    return :(NotImplemented($mod, $source, $info))
 end

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -64,7 +64,7 @@ returns `true`.
     has worked out analytically differentials of some but not all of them.
 
 !!! note
-    It is good practice to provide a link to a Github issue about the missing
+    It is good practice to provide a link to a GitHub issue about the missing
     differential as additional debugging information.
 """
 macro not_implemented(info=nothing)

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -9,28 +9,14 @@ struct NotImplemented{M,S,I} <: AbstractDifferential
     info::I
 end
 
-# required for `@scalar_rule` (together with `conj(x::AbstractDifferential) = x`)
-Base.muladd(x::NotImplemented, ::Any, ::Any) = x
-Base.muladd(x::NotImplemented, ::Any, ::NotImplemented) = x
-Base.muladd(::Any, ::Any, x::NotImplemented) = x
-Base.:*(x::NotImplemented, ::Any) = x
+# required for `@scalar_rule`
+# (together with `conj(x::AbstractDifferential) = x` and the definitions in
+# differential_arithmetic.jl)
 Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
 
 # throw error with debugging information for other standard information
+# (`+`, `-`, `*`, and `dot` are defined in differential_arithmetic.jl)
 extern(x::NotImplemented) = throw(NotImplementedException(x))
-
-Base.:+(x::NotImplemented) = throw(NotImplementedException(x))
-Base.:+(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
-Base.:+(::Any, x::NotImplemented) = throw(NotImplementedException(x))
-Base.:+(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
-
-Base.:-(x::NotImplemented) = throw(NotImplementedException(x))
-Base.:-(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
-Base.:-(::Any, x::NotImplemented) = throw(NotImplementedException(x))
-Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
-
-Base.:*(::Any, x::NotImplemented) = throw(NotImplementedException(x))
-Base.:*(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
 Base.:/(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -39,8 +39,11 @@ Optionally, you can provide additional information such as a Github issue
 about the missing differential. Debugging information is only tracked and
 displayed if `ChainRulesCore.debug_mode()` returns `true`.
 """
-macro not_implemented(info=nothing)
-    mod = debug_mode() ? __module__ : nothing
-    source = debug_mode() ? QuoteNode(__source__) : nothing
+macro not_implemented(_info=nothing)
+    mod, source, info = if debug_mode()
+        __module__, QuoteNode(__source__), _info
+    else
+        nothing, nothing, nothing
+    end
     return :(NotImplemented($mod, $source, $info))
 end

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -62,8 +62,6 @@ end
 Create a differential that indicates that the derivative is not implemented.
 
 Optionally, one can provide additional information about the missing differential.
-Debugging information is only tracked and displayed if `ChainRulesCore.debug_mode()`
-returns `true`.
 
 !!! note
     This macro should be used only if the automatic differentiation would error
@@ -75,11 +73,7 @@ returns `true`.
     differential as additional debugging information.
 """
 macro not_implemented(info=nothing)
-    return if debug_mode()
-        :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
-    else
-        :(NotImplemented())
-    end
+    :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
 end
 
 struct NotImplementedException{T<:NotImplemented} <: Exception

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -11,23 +11,38 @@ end
 
 NotImplemented() = NotImplemented(nothing, nothing, nothing)
 
+# required for `@scalar_rule` (together with `conj(x::AbstractDifferential) = x`)
+Base.muladd(x::NotImplemented, ::Any, ::Any) = x
+Base.muladd(x::NotImplemented, ::Any, ::NotImplemented) = x
+Base.muladd(::Any, ::Any, x::NotImplemented) = x
+Base.:*(x::NotImplemented, ::Any) = x
+Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
+
+# throw error with debugging information for other standard information
 extern(x::NotImplemented) = throw(NotImplementedException(x))
+
+Base.:+(x::NotImplemented) = throw(NotImplementedException(x))
+Base.:+(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
+Base.:+(::Any, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:+(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+
+Base.:-(x::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
+Base.:-(::Any, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+
+Base.:*(::Any, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:*(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
+
+Base.:/(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
+Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:/(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
 Base.iterate(x::NotImplemented) = throw(NotImplementedException(x))
 Base.iterate(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 
-Base.:+(x::NotImplemented, ::Any) = x
-Base.:+(::Any, x::NotImplemented) = x
-Base.:+(x::NotImplemented, ::NotImplemented) = x
-Base.:*(x::NotImplemented, ::Any) = x
-Base.:*(::Any, x::NotImplemented) = x
-Base.:*(x::NotImplemented, ::NotImplemented) = x
-
-# Linear operators
-Base.adjoint(x::NotImplemented) = x
-Base.transpose(x::NotImplemented) = x
-
-Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
+Base.adjoint(x::NotImplemented) = throw(NotImplementedException(x))
+Base.transpose(x::NotImplemented) = throw(NotImplementedException(x))
 
 Base.convert(::Type{<:Number}, x::NotImplemented) = throw(NotImplementedException(x))
 

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -46,8 +46,8 @@ Optionally, one can provide additional information about the missing differentia
 
 !!! note
     This macro should be used only if the automatic differentiation would error
-    otherwise. It is mostly useful if the function has multiple inputs and one
-    has worked out analytically differentials of some but not all of them.
+    otherwise. It is mostly useful if the function has multiple inputs or outputs,
+    and one has worked out analytically and implemented some but not all differentials.
 
 !!! note
     It is good practice to provide a link to a GitHub issue about the missing

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -1,0 +1,53 @@
+"""
+    NotImplemented
+
+This differential indicates that the derivative is not implemented.
+"""
+struct NotImplemented{M,S,I} <: AbstractDifferential
+    mod::M
+    source::S
+    info::I
+end
+
+extern(x::NotImplemented) = _error(x)
+
+Base.zero(x::NotImplemented) = _error(x)
+Base.zero(::Type{<:NotImplemented}) = _error(NotImplemented(nothing, nothing, nothing))
+
+Base.iterate(x::NotImplemented) = _error(x)
+Base.iterate(x::NotImplemented, ::Any) = _error(x)
+
+Base.adjoint(x::NotImplemented) = _error(x)
+Base.conj(x::NotImplemented) = _error(x)
+Base.transpose(x::NotImplemented) = _error(x)
+
+Base.:+(x::NotImplemented) = _error(x)
+Base.:/(x::NotImplemented, ::Any) = _error(x)
+
+Base.Broadcast.broadcastable(x::NotImplemented) = _error(x)
+
+_error(::NotImplemented) = error("differential not implemented")
+function _error(x::NotImplemented{Module,LineNumberNode})
+    error(
+        "differential not implemented @ ",
+        x.mod,
+        " ",
+        x.source,
+        x.info === nothing ? "" : "\nInfo: " * x.info,
+    )
+end
+
+"""
+    @not_implemented(info=nothing)
+
+Create a differential that indicates that the derivative is not implemented.
+
+Optionally, you can provide additional information such as a Github issue
+about the missing differential. Debugging information is only tracked and
+displayed if `ChainRulesCore.debug_mode()` returns `true`.
+"""
+macro not_implemented(info=nothing)
+    mod = debug_mode() ? __module__ : nothing
+    source = debug_mode() ? QuoteNode(__source__) : nothing
+    return :(NotImplemented($mod, $source, $info))
+end

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -11,20 +11,13 @@ end
 
 extern(x::NotImplemented) = _error(x)
 
-Base.zero(x::NotImplemented) = _error(x)
-Base.zero(::Type{<:NotImplemented}) = _error(NotImplemented(nothing, nothing, nothing))
-
 Base.iterate(x::NotImplemented) = _error(x)
 Base.iterate(x::NotImplemented, ::Any) = _error(x)
 
-Base.adjoint(x::NotImplemented) = _error(x)
-Base.conj(x::NotImplemented) = _error(x)
-Base.transpose(x::NotImplemented) = _error(x)
-
 Base.:+(x::NotImplemented) = _error(x)
-Base.:/(x::NotImplemented, ::Any) = _error(x)
+Base.:*(x::NotImplemented, ::Any) = x
 
-Base.Broadcast.broadcastable(x::NotImplemented) = _error(x)
+Base.Broadcast.broadcastable(x::NotImplemented) = Ref(x)
 
 _error(::NotImplemented) = error("differential not implemented")
 function _error(x::NotImplemented{Module,LineNumberNode})

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -54,9 +54,18 @@ end
 
 Create a differential that indicates that the derivative is not implemented.
 
-Optionally, you can provide additional information such as a Github issue
-about the missing differential. Debugging information is only tracked and
-displayed if `ChainRulesCore.debug_mode()` returns `true`.
+Optionally, one can provide additional information about the missing differential.
+Debugging information is only tracked and displayed if `ChainRulesCore.debug_mode()`
+returns `true`.
+
+!!! note:
+    This macro should be used only if the automatic differentiation would error
+    otherwise. It is mostly useful if the function has multiple inputs and one
+    has worked out analytically differentials of some but not all of them.
+
+!!! note:
+    It is good practice to provide a link to a Github issue about the missing
+    differential as additional debugging information.
 """
 macro not_implemented(info=nothing)
     return if debug_mode()

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -42,6 +42,13 @@ function _error(x::NotImplemented{Module,LineNumberNode})
     )
 end
 
+function Base.show(io::IO, ::NotImplemented{Nothing,Nothing,Nothing})
+    return print(io, "NotImplemented()")
+end
+function Base.show(io::IO, x::NotImplemented)
+    return print(io, "NotImplemented(", x.mod, ", ", x.source, ", ", x.info, ")")
+end
+
 """
     @not_implemented(info=nothing)
 

--- a/test/differentials/notimplemented.jl
+++ b/test/differentials/notimplemented.jl
@@ -3,7 +3,9 @@
         ni = ChainRulesCore.NotImplemented(
             @__MODULE__, LineNumberNode(@__LINE__, @__FILE__), "error"
         )
-        ni2 = ChainRulesCore.NotImplemented(nothing, nothing, nothing)
+        ni2 = ChainRulesCore.NotImplemented(
+            @__MODULE__, LineNumberNode(@__LINE__, @__FILE__), "error2"
+        )
 
         # supported operations (for `@scalar_rule`)
         x, y, z = rand(3)
@@ -88,12 +90,6 @@
     end
 
     @testset "@not_implemented" begin
-        ni = @not_implemented()
-        @test ni isa ChainRulesCore.NotImplemented
-        @test ni.mod isa Module
-        @test ni.source isa LineNumberNode
-        @test ni.info === nothing
-
         ni = @not_implemented("myerror")
         @test ni isa ChainRulesCore.NotImplemented
         @test ni.mod isa Module
@@ -102,12 +98,6 @@
     end
 
     @testset "NotImplementedException" begin
-        ex = ChainRulesCore.NotImplementedException()
-        @test ex isa ChainRulesCore.NotImplementedException
-        @test ex.mod === nothing
-        @test ex.source === nothing
-        @test ex.info === nothing
-
         ni = @not_implemented("not implemented")
         ex = ChainRulesCore.NotImplementedException(ni)
         @test ex isa ChainRulesCore.NotImplementedException
@@ -118,7 +108,7 @@
 
     @testset "@scalar_rule" begin
         notimplemented1(x, y) = x + y
-        @scalar_rule notimplemented1(x, y) (@not_implemented(), 1)
+        @scalar_rule notimplemented1(x, y) (@not_implemented("notimplemented1"), 1)
 
         y, ẏ = frule((NO_FIELDS, 1.2, 2.3), notimplemented1, 3, 2)
         @test y == 5
@@ -132,7 +122,7 @@
         @test x̄2 == 3.1
 
         notimplemented2(x, y) = (x + y, x - y)
-        @scalar_rule notimplemented2(x, y) (@not_implemented(), 1) (1, -1)
+        @scalar_rule notimplemented2(x, y) (@not_implemented("notimplemented2"), 1) (1, -1)
 
         y, (ẏ1, ẏ2) = frule((NO_FIELDS, 1.2, 2.3), notimplemented2, 3, 2)
         @test y == (5, 1)

--- a/test/differentials/notimplemented.jl
+++ b/test/differentials/notimplemented.jl
@@ -120,7 +120,7 @@
         notimplemented1(x, y) = x + y
         @scalar_rule notimplemented1(x, y) (@not_implemented(), 1)
 
-        y, ẏ = frule((Zero(), 1.2, 2.3), notimplemented1, 3, 2)
+        y, ẏ = frule((NO_FIELDS, 1.2, 2.3), notimplemented1, 3, 2)
         @test y == 5
         @test ẏ isa ChainRulesCore.NotImplemented
 
@@ -134,7 +134,7 @@
         notimplemented2(x, y) = (x + y, x - y)
         @scalar_rule notimplemented2(x, y) (@not_implemented(), 1) (1, -1)
 
-        y, (ẏ1, ẏ2) = frule((Zero(), 1.2, 2.3), notimplemented2, 3, 2)
+        y, (ẏ1, ẏ2) = frule((NO_FIELDS, 1.2, 2.3), notimplemented2, 3, 2)
         @test y == (5, 1)
         @test ẏ1 isa ChainRulesCore.NotImplemented
         @test ẏ2 ≈ -1.1

--- a/test/differentials/notimplemented.jl
+++ b/test/differentials/notimplemented.jl
@@ -1,0 +1,114 @@
+@testset "NotImplemented" begin
+    @testset "NotImplemented" begin
+        ni = ChainRulesCore.NotImplemented(
+            @__MODULE__, LineNumberNode(@__LINE__, @__FILE__), "error"
+        )
+        ni2 = ChainRulesCore.NotImplemented(nothing, nothing, nothing)
+
+        # supported operations (for `@scalar_rule`)
+        x, y, z = rand(3)
+        @test conj(ni) === ni
+        @test muladd(ni, y, z) === ni
+        @test muladd(ni, Zero(), z) == z
+        @test muladd(ni, y, Zero()) === ni
+        @test muladd(ni, Zero(), Zero()) == Zero()
+        @test muladd(ni, ni2, z) === ni
+        @test muladd(ni, ni2, Zero()) === ni
+        @test muladd(ni, y, ni2) === ni
+        @test muladd(ni, Zero(), ni2) === ni2
+        @test muladd(x, ni, z) === ni
+        @test muladd(Zero(), ni, z) == z
+        @test muladd(x, ni, Zero()) === ni
+        @test muladd(Zero(), ni, Zero()) == Zero()
+        @test muladd(x, ni, ni2) === ni
+        @test muladd(Zero(), ni, ni2) === ni2
+        @test ni * rand() === ni
+        @test ni * Zero() == Zero()
+        @test Zero() * ni == Zero()
+        @test dot(ni, Zero()) == Zero()
+        @test dot(Zero(), ni) == Zero()
+        @test ni .* rand() === ni
+        @test broadcastable(ni) isa Ref{typeof(ni)}
+
+        # unsupported operations
+        E = ChainRulesCore.NotImplementedException
+        @test_throws E extern(ni)
+        @test_throws E +ni
+        @test_throws E ni + rand()
+        @test_throws E ni + Zero()
+        @test_throws E ni + DoesNotExist()
+        @test_throws E ni + One()
+        @test_throws E ni + @thunk(x^2)
+        @test_throws E rand() + ni
+        @test_throws E Zero() + ni
+        @test_throws E DoesNotExist() + ni
+        @test_throws E One() + ni
+        @test_throws E @thunk(x^2) + ni
+        @test_throws E ni + ni2
+        @test_throws E -ni
+        @test_throws E ni - rand()
+        @test_throws E ni - Zero()
+        @test_throws E ni - DoesNotExist()
+        @test_throws E ni - One()
+        @test_throws E ni - @thunk(x^2)
+        @test_throws E rand() - ni
+        @test_throws E Zero() - ni
+        @test_throws E DoesNotExist() - ni
+        @test_throws E One() - ni
+        @test_throws E @thunk(x^2) - ni
+        @test_throws E ni - ni2
+        @test_throws E rand() * ni
+        @test_throws E DoesNotExist() * ni
+        @test_throws E One() * ni
+        @test_throws E @thunk(x^2) * ni
+        @test_throws E ni * ni2
+        @test_throws E dot(ni, rand())
+        @test_throws E dot(ni, DoesNotExist())
+        @test_throws E dot(ni, One())
+        @test_throws E dot(ni, @thunk(x^2))
+        @test_throws E dot(rand(), ni)
+        @test_throws E dot(DoesNotExist(), ni)
+        @test_throws E dot(One(), ni)
+        @test_throws E dot(@thunk(x^2), ni)
+        @test_throws E dot(ni, ni2)
+        @test_throws E ni / rand()
+        @test_throws E rand() / ni
+        @test_throws E ni / ni2
+        @test_throws E zero(ni)
+        @test_throws E zero(typeof(ni))
+        @test_throws E iterate(ni)
+        @test_throws E iterate(ni, nothing)
+        @test_throws E adjoint(ni)
+        @test_throws E transpose(ni)
+        @test_throws E convert(Float64, ni)
+    end
+
+    @testset "@not_implemented" begin
+        ni = @not_implemented()
+        @test ni isa ChainRulesCore.NotImplemented
+        @test ni.mod isa Module
+        @test ni.source isa LineNumberNode
+        @test ni.info === nothing
+
+        ni = @not_implemented("myerror")
+        @test ni isa ChainRulesCore.NotImplemented
+        @test ni.mod isa Module
+        @test ni.source isa LineNumberNode
+        @test ni.info == "myerror"
+    end
+
+    @testset "NotImplementedException" begin
+        ex = ChainRulesCore.NotImplementedException()
+        @test ex isa ChainRulesCore.NotImplementedException
+        @test ex.mod === nothing
+        @test ex.source === nothing
+        @test ex.info === nothing
+
+        ni = @not_implemented("not implemented")
+        ex = ChainRulesCore.NotImplementedException(ni)
+        @test ex isa ChainRulesCore.NotImplementedException
+        @test ex.mod === ni.mod
+        @test ex.source === ni.source
+        @test ex.info === ni.info
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ using Test
         include("differentials/one.jl")
         include("differentials/thunks.jl")
         include("differentials/composite.jl")
+        include("differentials/notimplemented.jl")
     end
 
     include("accumulation.jl")


### PR DESCRIPTION
This is a first draft that addresses https://github.com/JuliaDiff/ChainRulesCore.jl/issues/334. It adds an unexported `NotImplemented` differential that is constructed with an exported `@not_implemented` helper. If `ChainRulesCore.debug_mode() == true`, it tracks debugging information such as module and location where the differential is missing and, possibly, additional user-provided information. It throws an error if one tries to perform computations with the differential (I just implemented some of the methods that are defined for other differentials but maybe the list should be shortened or extended).

Examples:
```julia
julia> ChainRulesCore.debug_mode() = false # default

julia> zero(ChainRulesCore.@not_implemented())
ERROR: differential not implemented
Stacktrace:
...

julia> zero(ChainRulesCore.@not_implemented("more info"))
ERROR: differential not implemented
Stacktrace:
...

julia> ChainRulesCore.debug_mode() = true

julia> zero(ChainRulesCore.@not_implemented())
ERROR: differential not implemented @ Main #= REPL[18]:1 =#
Stacktrace:
...

julia> zero(ChainRulesCore.@not_implemented("more info"))
ERROR: differential not implemented @ Main #= REPL[20]:1 =#
Info: more info
Stacktrace:
...
```

I haven't checked yet if/how breaking it is for Zygote.