### PR TITLE
Allow to sum `NotImplemented`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.38"
+version = "0.9.39"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/differential_arithmetic.jl
+++ b/src/differential_arithmetic.jl
@@ -13,65 +13,58 @@ Notice:
     defines the combination this type with all types of  lower precidence.
     This means each eval loops is 1 item smaller than the previous.
 ==#
+
+# we propagate `NotImplemented` (e.g., in `@scalar_rule`)
+# this requires the following definitions (see also #337)
+Base.:+(x::NotImplemented, ::Zero) = x
+Base.:+(::Zero, x::NotImplemented) = x
+Base.:+(x::NotImplemented, ::NotImplemented) = x
+Base.:*(::NotImplemented, ::Zero) = Zero()
+Base.:*(::Zero, ::NotImplemented) = Zero()
+for T in (:DoesNotExist, :One, :AbstractThunk, :Composite, :Any)
+    @eval Base.:+(x::NotImplemented, ::$T) = x
+    @eval Base.:+(::$T, x::NotImplemented) = x
+    @eval Base.:*(x::NotImplemented, ::$T) = x
+end
+Base.muladd(x::NotImplemented, y, z) = x
+Base.muladd(::NotImplemented, ::Zero, z) = z
+Base.muladd(x::NotImplemented, y, ::Zero) = x
+Base.muladd(::NotImplemented, ::Zero, ::Zero) = Zero()
+Base.muladd(x, y::NotImplemented, z) = y
+Base.muladd(::Zero, ::NotImplemented, z) = z
+Base.muladd(x, y::NotImplemented, ::Zero) = y
+Base.muladd(::Zero, ::NotImplemented, ::Zero) = Zero()
+Base.muladd(x, y, z::NotImplemented) = z
+Base.muladd(::Zero, y, z::NotImplemented) = z
+Base.muladd(x, ::Zero, z::NotImplemented) = z
+Base.muladd(::Zero, ::Zero, z::NotImplemented) = z
+Base.muladd(x::NotImplemented, ::NotImplemented, z) = x
+Base.muladd(x::NotImplemented, ::NotImplemented, ::Zero) = x
+Base.muladd(x::NotImplemented, y, ::NotImplemented) = x
+Base.muladd(::NotImplemented, ::Zero, z::NotImplemented) = z
+Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
+Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
+Base.muladd(x::NotImplemented, ::NotImplemented, ::NotImplemented) = x
+LinearAlgebra.dot(::NotImplemented, ::Zero) = Zero()
+LinearAlgebra.dot(::Zero, ::NotImplemented) = Zero()
+
+# other common operations throw an exception
 Base.:+(x::NotImplemented) = throw(NotImplementedException(x))
-Base.:+(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
-Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 Base.:-(x::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
+Base.:-(::Zero, x::NotImplemented) = throw(NotImplementedException(x))
+Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 Base.:*(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 function LinearAlgebra.dot(x::NotImplemented, ::NotImplemented)
     return throw(NotImplementedException(x))
 end
 for T in (:DoesNotExist, :One, :AbstractThunk, :Composite, :Any)
-    @eval Base.:+(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
-    @eval Base.:+(::$T, x::NotImplemented) = throw(NotImplementedException(x))
     @eval Base.:-(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
     @eval Base.:-(::$T, x::NotImplemented) = throw(NotImplementedException(x))
-
     @eval Base.:*(::$T, x::NotImplemented) = throw(NotImplementedException(x))
-
     @eval LinearAlgebra.dot(x::NotImplemented, ::$T) = throw(NotImplementedException(x))
     @eval LinearAlgebra.dot(::$T, x::NotImplemented) = throw(NotImplementedException(x))
-
-    # required for `@scalar_rule`
-    @eval Base.:*(x::NotImplemented, ::$T) = x
 end
-
-# required for `@scalar_rule`
-Base.muladd(x::NotImplemented, y, z) = x
-Base.muladd(::NotImplemented, ::Zero, z) = z
-Base.muladd(x::NotImplemented, y, ::Zero) = x
-Base.muladd(::NotImplemented, ::Zero, ::Zero) = Zero()
-
-Base.muladd(x, y::NotImplemented, z) = y
-Base.muladd(::Zero, ::NotImplemented, z) = z
-Base.muladd(x, y::NotImplemented, ::Zero) = y
-Base.muladd(::Zero, ::NotImplemented, ::Zero) = Zero()
-
-Base.muladd(x, y, z::NotImplemented) = z
-Base.muladd(::Zero, y, z::NotImplemented) = z
-Base.muladd(x, ::Zero, z::NotImplemented) = z
-Base.muladd(::Zero, ::Zero, z::NotImplemented) = z
-
-Base.muladd(x::NotImplemented, ::NotImplemented, z) = x
-Base.muladd(x::NotImplemented, ::NotImplemented, ::Zero) = x
-
-Base.muladd(x::NotImplemented, y, ::NotImplemented) = x
-Base.muladd(::NotImplemented, ::Zero, z::NotImplemented) = z
-
-Base.muladd(x, y::NotImplemented, ::NotImplemented) = y
-Base.muladd(::Zero, ::NotImplemented, z::NotImplemented) = z
-
-Base.muladd(x::NotImplemented, ::NotImplemented, ::NotImplemented) = x
-
-# similar to `DoesNotExist`, `Zero` wins `*` and `NotImplemented` wins `+`
-Base.:+(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
-Base.:+(::Zero, x::NotImplemented) = throw(NotImplementedException(x))
-Base.:-(x::NotImplemented, ::Zero) = throw(NotImplementedException(x))
-Base.:-(::Zero, x::NotImplemented) = throw(NotImplementedException(x))
-Base.:*(::NotImplemented, ::Zero) = Zero()
-Base.:*(::Zero, ::NotImplemented) = Zero()
-LinearAlgebra.dot(::NotImplemented, ::Zero) = Zero()
-LinearAlgebra.dot(::Zero, ::NotImplemented) = Zero()
 
 Base.:+(::DoesNotExist, ::DoesNotExist) = DoesNotExist()
 Base.:-(::DoesNotExist, ::DoesNotExist) = DoesNotExist()

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -228,12 +228,7 @@ end
 construct(::Type{T}, fields::T) where T<:NamedTuple = fields
 construct(::Type{T}, fields::T) where T<:Tuple = fields
 
-add_element(x, y) = x + y
-add_element(x::NotImplemented, y) = x
-add_element(x, y::NotImplemented) = y
-add_element(x::NotImplemented, ::NotImplemented) = x
-
-elementwise_add(a::Tuple, b::Tuple) = map(add_element, a, b)
+elementwise_add(a::Tuple, b::Tuple) = map(+, a, b)
 
 function elementwise_add(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
     # Rule of Composite addition: any fields not present are implict hard Zeros
@@ -249,7 +244,7 @@ function elementwise_add(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
             value_expr = if Base.sym_in(field, an)
                 if Base.sym_in(field, bn)
                     # in both
-                    :(add_element($a_field, $b_field))
+                    :($a_field + $b_field)
                 else
                     # only in `an`
                     a_field
@@ -268,7 +263,7 @@ function elementwise_add(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
                 if Base.sym_in(field, bn)
                     # in both
                     b_field = getproperty(b, field)
-                    add_element(a_field, b_field)
+                    a_field + b_field
                 else
                     # only in `an`
                     a_field
@@ -282,7 +277,7 @@ function elementwise_add(a::NamedTuple{an}, b::NamedTuple{bn}) where {an, bn}
     end
 end
 
-elementwise_add(a::Dict, b::Dict) = merge(add_element, a, b)
+elementwise_add(a::Dict, b::Dict) = merge(+, a, b)
 
 struct PrimalAdditionFailedException{P} <: Exception
     primal::P

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -200,6 +200,41 @@ end
             d_sum = Composite{Dict}(Dict(4 => 3.0 + 3.0, 3 => 2.0, 2 => 2.0))
             @test d1 + d2 == d_sum
         end
+
+        @testset "Fields of type NotImplemented" begin
+            CFoo = Composite{Foo}
+            a = CFoo(x=1.5)
+            b = CFoo(x=@not_implemented(""))
+            for (x, y) in ((a, b), (b, a), (b, b))
+                z = x + y
+                @test z isa CFoo
+                @test z.x isa ChainRulesCore.NotImplemented
+            end
+
+            a = Composite{Tuple}(1.5)
+            b = Composite{Tuple}(@not_implemented(""))
+            for (x, y) in ((a, b), (b, a), (b, b))
+                z = x + y
+                @test z isa Composite{Tuple}
+                @test first(z) isa ChainRulesCore.NotImplemented
+            end
+
+            a = Composite{NamedTuple{(:x,)}}(x=1.5)
+            b = Composite{NamedTuple{(:x,)}}(x=@not_implemented(""))
+            for (x, y) in ((a, b), (b, a), (b, b))
+                z = x + y
+                @test z isa Composite{NamedTuple{(:x,)}}
+                @test z.x isa ChainRulesCore.NotImplemented
+            end
+
+            a = Composite{Dict}(Dict(:x => 1.5))
+            b = Composite{Dict}(Dict(:x => @not_implemented("")))
+            for (x, y) in ((a, b), (b, a), (b, b))
+                z = x + y
+                @test z isa Composite{Dict}
+                @test z[:x] isa ChainRulesCore.NotImplemented
+            end
+        end
     end
 
     @testset "+ with Primals" begin

--- a/test/differentials/notimplemented.jl
+++ b/test/differentials/notimplemented.jl
@@ -28,6 +28,17 @@
         @test muladd(Zero(), y, ni) === ni
         @test muladd(x, Zero(), ni) === ni
         @test muladd(Zero(), Zero(), ni) === ni
+        @test ni + rand() === ni
+        @test ni + Zero() === ni
+        @test ni + DoesNotExist() === ni
+        @test ni + One() === ni
+        @test ni + @thunk(x^2) === ni
+        @test rand() + ni === ni
+        @test Zero() + ni === ni
+        @test DoesNotExist() + ni === ni
+        @test One() + ni === ni
+        @test @thunk(x^2) + ni === ni
+        @test ni + ni2 === ni
         @test ni * rand() === ni
         @test ni * Zero() == Zero()
         @test Zero() * ni == Zero()
@@ -40,17 +51,6 @@
         E = ChainRulesCore.NotImplementedException
         @test_throws E extern(ni)
         @test_throws E +ni
-        @test_throws E ni + rand()
-        @test_throws E ni + Zero()
-        @test_throws E ni + DoesNotExist()
-        @test_throws E ni + One()
-        @test_throws E ni + @thunk(x^2)
-        @test_throws E rand() + ni
-        @test_throws E Zero() + ni
-        @test_throws E DoesNotExist() + ni
-        @test_throws E One() + ni
-        @test_throws E @thunk(x^2) + ni
-        @test_throws E ni + ni2
         @test_throws E -ni
         @test_throws E ni - rand()
         @test_throws E ni - Zero()


### PR DESCRIPTION
This PR fixes the test failures in https://github.com/JuliaDiff/ChainRulesTestUtils.jl/pull/140.

~~Alternatively, one could~~ This PR allows `+(::NotImplemented, y)` (and permutations) more generally.