### PR TITLE
Escape information in `@not_implemented`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.39"
+version = "0.9.40"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/differentials/notimplemented.jl
+++ b/src/differentials/notimplemented.jl
@@ -15,7 +15,7 @@ The `info` should be useful information about the missing differential for debug
     differential in the debugging information.
 """
 macro not_implemented(info)
-    return :(NotImplemented($__module__, $(QuoteNode(__source__)), $info))
+    return :(NotImplemented($__module__, $(QuoteNode(__source__)), $(esc(info))))
 end
 
 """

--- a/test/differentials/notimplemented.jl
+++ b/test/differentials/notimplemented.jl
@@ -95,6 +95,13 @@
         @test ni.mod isa Module
         @test ni.source isa LineNumberNode
         @test ni.info == "myerror"
+
+        info = "some info"
+        ni = @not_implemented(info)
+        @test ni isa ChainRulesCore.NotImplemented
+        @test ni.mod isa Module
+        @test ni.source isa LineNumberNode
+        @test ni.info === info
     end
 
     @testset "NotImplementedException" begin


### PR DESCRIPTION
With this PR the `@not_implemented` macro escapes the provided information.

I noticed that this would be useful when I updated SpecialFunctions in my fork (https://github.com/devmotion/SpecialFunctions.jl/tree/dw/notimplemented): now one can define a constant in the package and use it as message for multiple instances of `@not_implemented`.
