### PR TITLE
precompile package callback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.40"
+version = "0.9.41"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -30,4 +30,6 @@ include("rules.jl")
 include("rule_definition_tools.jl")
 include("ruleset_loading.jl")
 
+include("precompile.jl")
+
 end # module

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,1 @@
+precompile(_package_hook, (Base.PkgId,))

--- a/src/ruleset_loading.jl
+++ b/src/ruleset_loading.jl
@@ -1,7 +1,8 @@
 # Infastructure to support generating overloads from rules.
+_package_hook(::Base.PkgId) = refresh_rules()
 function __init__()
     # Need to refresh rules when a package is loaded
-    push!(Base.package_callbacks, pkgid -> refresh_rules())
+    push!(Base.package_callbacks, _package_hook)
 end
 
 # Holds all the hook functions that are invokes when a new rule is defined
@@ -139,3 +140,5 @@ function _safe_hook_fun(hook_fun, sig)
         @error "Error triggering hook" hook_fun sig exception=(err, catch_backtrace())
     end
 end
+
+precompile(_package_hook, (Base.PkgId,))

--- a/src/ruleset_loading.jl
+++ b/src/ruleset_loading.jl
@@ -140,5 +140,3 @@ function _safe_hook_fun(hook_fun, sig)
         @error "Error triggering hook" hook_fun sig exception=(err, catch_backtrace())
     end
 end
-
-precompile(_package_hook, (Base.PkgId,))


### PR DESCRIPTION
With this PR:
```
(ChainRulesCore) pkg> precompile
Precompiling project...
  1 dependency successfully precompiled in 2 seconds (1 already precompiled)

julia> @time using ChainRulesCore
  0.082255 seconds (157.13 k allocations: 9.737 MiB, 5.59% compilation time)
```

Before:
```
julia> @time using ChainRulesCore
  0.111551 seconds (443.47 k allocations: 25.618 MiB, 3.87% compilation time)
```

Removing the hook alltogether:
```
julia> @time using ChainRulesCore
  0.033357 seconds (36.37 k allocations: 2.399 MiB, 17.75% compilation time)
```

That's still more overhead than I'd like, so we should still discuss
whether we could avoid these hooks, but it does at least improve the current
situation somewhat.

Ref #340