### PR TITLE
tag new release to make available on Zenodo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.42"
+version = "0.9.43"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
I am trying to register ChainRules and related repos at https://zenodo.org/. For a repo to show up though, a new release has to be tagged. Sorry for the noise!
