### PR TITLE
deprecate NO_FIELDS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.0"
+version = "0.10.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,1 @@
+Base.@deprecate_binding NO_FIELDS NoTangent()

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,3 @@
+@testset "NO_FIELDS" begin
+    @test (@test_deprecated NO_FIELDS) isa NoTangent
+end


### PR DESCRIPTION
This deprecates `NO_FIELDS` to `NoTangent()`.
Note that this is not the same as the 0.9 behavour which had it as `ZeroTangent()`.
but it is close, and is the behavour we want going forward
(which is why we decided that this had to be in breaking change. But we ment to include it in the 0.10.0 release).