### PR TITLE
Improve docs for structs: constructors and functors

### DIFF
--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -1,5 +1,60 @@
 # On writing good `rrule` / `frule` methods
 
+## Use `Type{T}`, not `typeof(T)`, to define rules for constructors
+
+To define an `frule` or `rrule` for a _function_ `foo` we dispatch on the type of `foo`, which is `typeof(foo)`.
+For example, the `rrule` signature would be like:
+
+```julia
+function rrule(::typeof(foo), args...; kwargs...)
+    ...
+    return y, foo_pullback
+end
+```
+
+But to define an `rrule` for a constructor for a  _type_ `T` we need to be careful to dispatch only on `Type{T}`.
+
+For example, the `rrule` signature for a constructor would be like:
+
+```julia
+function rrule(::Type{T}, args...; kwargs...)
+    ...
+    return y, T_pullback
+end
+```
+
+In particular, be careful not to use `typeof(T)` here.
+Because `typeof(T)` is `DataType`, using this to define an `rrule`/`frule` will define an `rrule`/`frule` for all constructors.
+
+You can check which to use with `Core.Typeof`:
+
+```julia
+julia> function foob end
+foob (generic function with 0 methods)
+
+julia> typeof(foob)
+typeof(foob)
+
+julia> Core.Typeof(foob)
+typeof(foob)
+
+julia> abstract type AbstractT end
+
+julia> struct ExampleT <: AbstractT end
+
+julia> typeof(AbstractT)
+DataType
+
+julia> typeof(ExampleT)
+DataType
+
+julia> Core.Typeof(AbstractT)
+Type{AbstractT}
+
+julia> Core.Typeof(ExampleT)
+Type{ExampleT}
+```
+
 ## Use `ZeroTangent()` as the return value
 
 The `ZeroTangent()` object exists as an alternative to directly returning `0` or `zeros(n)`.

--- a/docs/src/writing_good_rules.md
+++ b/docs/src/writing_good_rules.md
@@ -85,6 +85,8 @@ end
 ```
 we can define an `frule`/`rrule` for the `Bar` constructor(s), as well as any `Bar` [functors](https://docs.julialang.org/en/v1/manual/methods/#Function-like-objects).
 
+### Constructors
+
 To define an `rrule` for a constructor for a  _type_ `Bar` we need to be careful to dispatch only on `Type{Bar}`.
 For example, the `rrule` signature for a `Bar` constructor would be like:
 ```julia
@@ -125,7 +127,10 @@ julia> Core.Typeof(AbstractT)
 Type{AbstractT}
 ```
 
-For the functor, use `bar::Bar`, i.e.
+### Functors (callable objects)
+
+In contrast to defining a rule for a constructor, it is possible to define rules for calling an instance of an object.
+In that case, use `bar::Bar`, i.e.
 
 ```julia
 function ChainRulesCore.rrule(bar::Bar, x, y)
@@ -134,7 +139,7 @@ function ChainRulesCore.rrule(bar::Bar, x, y)
     return bar(x, y), Bar_pullback
 end
 ```
-
+to define the rules.
 
 ## Use `@not_implemented` appropriately
 


### PR DESCRIPTION
This builds off @nickrobinson251's https://github.com/JuliaDiff/ChainRulesCore.jl/pull/331/files and adds an example struct, as well as adds a note on functors. I've also moved the Code Style to the top, as the generic signature is the most common thing people want.

Closes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/315