### PR TITLE
Implement `Base.:(==)` for thunks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.2"
+version = "0.10.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -13,6 +13,10 @@ end
     return element, (val, new_state)
 end
 
+Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
+Base.:(==)(a::AbstractThunk, b) = unthunk(a) == b
+Base.:(==)(a, b::AbstractThunk) = a == unthunk(b)
+
 """
     @thunk expr
 

--- a/test/differentials/thunks.jl
+++ b/test/differentials/thunks.jl
@@ -1,6 +1,12 @@
 @testset "Thunk" begin
     @test @thunk(3) isa Thunk
 
+    @testset "==" begin
+        @test @thunk(3.2) == @thunk(3.2)
+        @test @thunk(3.2) == 3.2
+        @test 3.2 == InplaceableThunk(@thunk(3.2), x -> x + 3.2)
+    end
+
     @testset "show" begin
         rep = repr(Thunk(rand))
         @test occursin(r"Thunk\(.*rand.*\)", rep)

--- a/test/differentials/thunks.jl
+++ b/test/differentials/thunks.jl
@@ -2,7 +2,7 @@
     @test @thunk(3) isa Thunk
 
     @testset "==" begin
-        @test @thunk(3.2) == @thunk(3.2)
+        @test @thunk(3.2) == InplaceableThunk(@thunk(3.2), x -> x + 3.2)
         @test @thunk(3.2) == 3.2
         @test 3.2 == InplaceableThunk(@thunk(3.2), x -> x + 3.2)
     end


### PR DESCRIPTION
Needed for defining `to_vec` for `@thunk`s, which is needed for [testing all kinds of differentials](https://github.com/JuliaDiff/ChainRulesTestUtils.jl/issues/159)