### PR TITLE
Deprecate calling thunks like functions

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -48,12 +48,9 @@ extern(x::NotImplemented) = (Base.depwarn(EXTERN_DEPRECATION, :extern); throw(No
 
 @inline extern(x::AbstractThunk) = (Base.depwarn(EXTERN_DEPRECATION, :extern); return extern(unthunk(x)))
 
-function (x::Thunk)()
-    Base.depwarn("`(x::Thunk)()`` is deprecated, use `unthunk(x)`", :call_Thunk)
-    unthunk(x)
-end
-
-function (x::InplaceableThunk)()
-    Base.depwarn("`(x::InplaceableThunk)()`` is deprecated, use `unthunk(x)`", :call_InplaceableThunk)
-    unthunk(x)
+for T in (:Thunk, :InplaceableThunk)
+    @eval function (x::$T)()
+        Base.depwarn("`(x::" * string($T) * ")()` is deprecated, use `unthunk(x)`", Symbol(:call_, $(T))) 
+        return unthunk(x)
+    end    
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -48,6 +48,12 @@ extern(x::NotImplemented) = (Base.depwarn(EXTERN_DEPRECATION, :extern); throw(No
 
 @inline extern(x::AbstractThunk) = (Base.depwarn(EXTERN_DEPRECATION, :extern); return extern(unthunk(x)))
 
+function (x::Thunk)()
+    Base.depwarn("`(x::Thunk)()`` is deprecated, use `unthunk(x)`", :call_Thunk)
+    unthunk(x)
+end
 
-
-
+function (x::InplaceableThunk)()
+    Base.depwarn("`(x::InplaceableThunk)()`` is deprecated, use `unthunk(x)`", :call_InplaceableThunk)
+    unthunk(x)
+end

--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -148,8 +148,7 @@ A thunk is a deferred computation.
 It wraps a zero argument closure that when invoked returns a differential.
 `@thunk(v)` is a macro that expands into `Thunk(()->v)`.
 
-Calling a thunk, calls the wrapped closure.
-If you are unsure if you have a `Thunk`, call [`unthunk`](@ref) which is a no-op when the
+To evaluate the wrapped closure, call [`unthunk`](@ref) which is a no-op when the
 argument is not a `Thunk`.
 
 ```jldoctest
@@ -159,7 +158,7 @@ Thunk(var"#4#6"())
 julia> t()
 Thunk(var"#5#7"())
 
-julia> t()()
+julia> unthunk(t())
 3
 ```
 
@@ -187,8 +186,7 @@ struct Thunk{F} <: AbstractThunk
     f::F
 end
 
-(x::Thunk)() = x.f()
-@inline unthunk(x::Thunk) = x()
+@inline unthunk(x::Thunk) = x.f()
 
 Base.show(io::IO, x::Thunk) = print(io, "Thunk($(repr(x.f)))")
 
@@ -210,7 +208,6 @@ struct InplaceableThunk{T<:Thunk,F} <: AbstractThunk
 end
 
 unthunk(x::InplaceableThunk) = unthunk(x.val)
-(x::InplaceableThunk)() = unthunk(x)
 
 function Base.show(io::IO, x::InplaceableThunk)
     return print(io, "InplaceableThunk($(repr(x.val)), $(repr(x.add!)))")

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -22,3 +22,9 @@ end
     E = ChainRulesCore.NotImplementedException
     @test_throws E extern(ni)
 end
+
+
+@testset "Deprecated: calling thunks should call inner function" begin
+    @test_deprecated (@thunk(3))() == 3
+    @test_deprecated (@thunk(@thunk(3)))() isa Thunk
+end

--- a/test/differentials/thunks.jl
+++ b/test/differentials/thunks.jl
@@ -27,11 +27,6 @@
         @test unthunk(@thunk(@thunk(3))) isa Thunk
     end
 
-    @testset "calling thunks should call inner function" begin
-        @test (@thunk(3))() == 3
-        @test (@thunk(@thunk(3)))() isa Thunk
-    end
-
     @testset "erroring thunks should include the source in the backtrack" begin
         expected_line = (@__LINE__) + 2  # for testing it is at right palce
         try


### PR DESCRIPTION
Always use `unthunk` instead.

Closes #374 .
