### PR TITLE
Write docs on converting ZygoteRules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/build
 docs/site
 docs/src/assets/chainrules.css
 docs/src/assets/indigo.css
+.vscode/settings.json

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -13,13 +13,13 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
 path = ".."
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.6"
+version = "0.10.7"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "e4e2b39db08f967cc1360951f01e8a75ec441cab"
+git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.30.0"
+version = "3.31.0"
 
 [[Dates]]
 deps = ["Printf"]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(
         "Debug Mode" => "debug_mode.md",
         "Gradient Accumulation" => "gradient_accumulation.md",
         "Usage in AD" => "use_in_ad_system.md",
+        "Converting ZygoteRules" => "converting_zygoterules.md",
         "Design" => [
             "Changing the Primal" => "design/changing_the_primal.md",
             "Many Differential Types" => "design/many_differentials.md",

--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -40,7 +40,7 @@ To the best of our knowledge no Julia AD system, with support for the definition
 At some point in the future ChainRules may support these. Maybe.
 
 
-## What is the difference between `ZeroTangent` and `NoTangent` ?
+## [What is the difference between `ZeroTangent` and `NoTangent` ?](@id faq_abstract_zero)
 `ZeroTangent` and `NoTangent` act almost exactly the same in practice: they result in no change whenever added to anything.
 Odds are if you write a rule that returns the wrong one everything will just work fine.
 We provide both to allow for clearer writing of rules, and easier debugging.

--- a/docs/src/complex.md
+++ b/docs/src/complex.md
@@ -1,4 +1,4 @@
-# How do chain rules work for complex functions?
+# [How do chain rules work for complex functions?](@id complexfunctions)
 
 ChainRules follows the convention that `frule` applied to a function ``f(x + i y) = u(x,y) + i v(x,y)`` with perturbation ``\Delta x + i \Delta y`` returns the value and
 ```math

--- a/docs/src/converting_zygoterules.md
+++ b/docs/src/converting_zygoterules.md
@@ -1,0 +1,133 @@
+# Converting ZygoteRules.@adjoint to `rrule`s
+
+[ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl) is a legacy package similar to ChainRules but supporting [Zygote.jl](https://github.com/FluxML/Zygote.jl) only.
+
+If you have some rules written with ZygoteRules it is a good idea to upgrade them to use ChainRules instead.
+Zygote will still be able to use them, but so will other AD systems,
+and you will get access to some more advanced features.
+(Which Zygote may or may not then ignore).
+
+## Example
+Consider the function
+```julia
+struct Foo
+    a::Float64,
+    b::Float64
+end
+
+f(x, y::Foo, z) = 2*x + y.a
+```
+
+### ZygoteRules
+```julia
+@adjoint function f(x, y::Foo, z)
+    f_pullback(Ω̄) = (2Ω̄, NamedTuple(;a=Ω̄, b=nothing), nothing)
+    return f(x, y, z), f_pullback
+end
+```
+
+### ChainRules
+```julia
+function rrule(::typeof(f), x, y::Foo, z)
+    f_pullback(Ω̄) = (NoFields(), 2Ω̄, Tangent{Foo}(;a=Ω̄), ZeroTangent())
+    return f(x, y, z), f_pullback
+end
+```
+
+## Write as a `rrule(::typeof(f), ...)`
+No magic macro here, `rrule` is the function that it is.
+The function it is the rule for is the first argument, or second argument if you need to take a `[RuleConfig`](@ref).
+
+## Include the derivative with respect to the function object itself
+The `ZygoteRules.@adjoint` macro automagically[^1] inserts a extra `nothing` in the return for the function it generates to represent the derivative of output with respect to the function object.
+ChainRules as a philosophy avoids magic as much as possible, and thus require you to return it explicitly.
+If it is a plain function (like `typeof(sin)`), then the differential will be [`NoTangent`](@ref).
+
+
+[^1]: unless you write it in functor form (i.e. `@adjoint (f::MyType)(args...)=...`), in that case like for `rrule` you need to include it explictly.
+
+## Tangent Type changes
+ChainRules uses tangent types that must represent vector spaces (i.e. tangent spaces).
+They need to have things like `+` defined on them.
+ZygoteRules takes a more adhoc approach to this.
+
+### `nothing` becomes an `AbstractZero`
+ZygoteRules uses nothing to represent some sense of zero, in a primal type agnostic way.
+There are many senses of zero.
+ChainRules represents two of them, as subtypes of [`AbstractZero`](@ref).
+
+[`ZeroTangent`](@ref) for the case that there is no relationship between the primal output and the primal input.
+[`NoTangent`](@ref) for the case that conceptually the tangent space don't exist.
+e.g. what is the Tangent to a String or an index: those can't be perturbed.
+
+See [FAQ on difference between `ZeroTangent` and `NoTangent`](@ref faq_abstract_zero).
+At the end of the day it doesn't matter too much if you get them wrong.
+`NoTangent` and `ZeroTangent` more or less act identically.
+
+### `Tuple`s and `NamedTuple`s become `Tangent{T}`s
+Zygote uses `Tuple`s and `NamedTuple`s to represent the structural tangents for `Tuple`s and `struct`s respectively.
+ChainRules core provides a generic `Tangent{T}`(@ref Tangent) to represent the structural tangent of a primal type `T`.
+It takes positional arguments if representing tangent for a `Tuple`.
+Or keyword argument to represent the tangent for a `struct`.
+When representing a `struct` you only need to list the nonzero fields -- any not given are implicit considered to be [`ZeroTangent`](@ref).
+
+When we say structural tangent we mean tangent types that are based only on the structure of the primal.
+This is in contrast to a natural tangent which captures some knowledge based on what the primal type represents.
+(E.g. for arrays a natural tangent is often the same kind of array).
+For more details see the the [design docs on the many tangent types](@ref manytypes)
+
+
+## Calling back into AD (`ZygoteRules.pullback`)
+Rules that need to call back into the AD system, e.g, for higher order functions like `map(f, xs)`, need to be changed.
+In `ZygoteRules` you can use `ZygoteRules.pullback` or `ZygoteRules._pullback`, which will always result in calling into Zygote.
+Since ChainRules is AD agnostic, you can't do that.
+Instead you use a [`RuleConfig`](@ref) to specify requirements of an AD system e.g `::RuleConfig{>:CanReverseMode}` work for Zygote,
+and then use [`rrule_via_ad`](@ref).
+
+See the [docs on calling back into AD](@ref config) for more details.
+
+## Consider adding some thunks
+
+A feature ChainRulesCore offers that ZygoteRules doesn't is support for thunks.
+Where work is delayed until it is needed, and avoided if it never is.
+See docs on [`@thunk`](@ref), [`Thunk`](@ref), [`InplaceableThunk`](@ref).
+
+You don't have to though.
+It is easy to go overboard with using thunks.
+
+## Testing Changes
+
+One of the advantages of using ChainRules is that you can easily and robustly test it with [ChainRulesTestUtils.jl](https://juliadiff.org/ChainRulesTestUtils.jl/stable/).
+This both uses finite differencing to test accuracy of derivative, as well as checking the correctness of the API.
+It should catch anything you might have gotten wrong referred to in this page.
+
+The test for the above example is `test_rrule(f, 2.5, Foo(9.9, 7.2), 31.0)`.
+You can see it looks a lot like an example call to `rrule`, just with the prefix `test_` added to the start.
+
+## `@nograd` becomes `@non_differentiable`
+Probably more or less with no changes.
+[`@non_differentiable`](@ref) also lets you specify a signature.
+
+## No such thing a `literal_getproperty`
+That is just `getproperty`, it takes `Symbol`.
+It should constant-fold.
+It likely doesn't though as Zygote doesn't play nice with the optimizer.
+
+## Take embedded spaces and types seriously
+Traditionally Zygote has taken a very laissez faire attitude towards types and mathematical spaces.
+Sometimes treating `Real`s as embedded in the `Complex` plane; some time not.
+Sometimes treating sparse and structuredly-sparse matrix as embedded in the space of dense matrixes.
+Writing rules that apply to any `Array{T}` which perhaps are only applicable for `Array{<:Real}` and not so much for `Array{Quaternion}`.
+Traditionally ChainRules takes a much more considered approach.
+
+See for example our [docs on how to handle complex numbers](@ref complexfunctions) correctly.
+(The outcome of several long long long discussions with a number of expert in our community)
+
+Now, I am not here to tell you what to do in your package, but this is a good time to reconsider how seriously you take these things in the rules you are converting.
+
+## What if I miss something
+
+It is not great, but it probably OK.
+Zygote's ChainRules interface is fairly forgiving.
+Other AD systems may not be.
+If you test with [ChainRulesTestUtils.jl](https://juliadiff.org/ChainRulesTestUtils.jl/stable/) then you can be confident that you didn't miss anything.

--- a/docs/src/converting_zygoterules.md
+++ b/docs/src/converting_zygoterules.md
@@ -38,6 +38,9 @@ end
 No magic macro here, `rrule` is the function that it is.
 The function it is the rule for is the first argument, or second argument if you need to take a `[RuleConfig`](@ref).
 
+Note that when writing the rule for constructor you will need to use `::Type{Foo}`, not `typeof(Foo)`.
+See docs on [Constructors](@ref).
+
 ## Include the derivative with respect to the function object itself
 The `ZygoteRules.@adjoint` macro automagically[^1] inserts a extra `nothing` in the return for the function it generates to represent the derivative of output with respect to the function object.
 ChainRules as a philosophy avoids magic as much as possible, and thus require you to return it explicitly.

--- a/docs/src/converting_zygoterules.md
+++ b/docs/src/converting_zygoterules.md
@@ -1,11 +1,11 @@
 # Converting ZygoteRules.@adjoint to `rrule`s
 
-[ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl) is a legacy package similar to ChainRules but supporting [Zygote.jl](https://github.com/FluxML/Zygote.jl) only.
+[ZygoteRules.jl](https://github.com/FluxML/ZygoteRules.jl) is a legacy package similar to ChainRulesCore but supporting [Zygote.jl](https://github.com/FluxML/Zygote.jl) only.
 
 If you have some rules written with ZygoteRules it is a good idea to upgrade them to use ChainRules instead.
 Zygote will still be able to use them, but so will other AD systems,
 and you will get access to some more advanced features.
-(Which Zygote may or may not then ignore).
+Some of these features are currently ignored by Zygote, but could be supported in the future.
 
 ## Example
 Consider the function
@@ -29,20 +29,20 @@ end
 ### ChainRules
 ```julia
 function rrule(::typeof(f), x, y::Foo, z)
-    f_pullback(Ω̄) = (NoFields(), 2Ω̄, Tangent{Foo}(;a=Ω̄), ZeroTangent())
+    f_pullback(Ω̄) = (NoTangent(), 2Ω̄, Tangent{Foo}(;a=Ω̄), ZeroTangent())
     return f(x, y, z), f_pullback
 end
 ```
 
 ## Write as a `rrule(::typeof(f), ...)`
 No magic macro here, `rrule` is the function that it is.
-The function it is the rule for is the first argument, or second argument if you need to take a `[RuleConfig`](@ref).
+The function it is the rule for is the first argument, or second argument if you need to take a [`RuleConfig`](@ref).
 
 Note that when writing the rule for constructor you will need to use `::Type{Foo}`, not `typeof(Foo)`.
 See docs on [Constructors](@ref).
 
 ## Include the derivative with respect to the function object itself
-The `ZygoteRules.@adjoint` macro automagically[^1] inserts a extra `nothing` in the return for the function it generates to represent the derivative of output with respect to the function object.
+The `ZygoteRules.@adjoint` macro automagically[^1] inserts an extra `nothing` in the return for the function it generates to represent the derivative of output with respect to the function object.
 ChainRules as a philosophy avoids magic as much as possible, and thus require you to return it explicitly.
 If it is a plain function (like `typeof(sin)`), then the differential will be [`NoTangent`](@ref).
 
@@ -60,18 +60,18 @@ There are many senses of zero.
 ChainRules represents two of them, as subtypes of [`AbstractZero`](@ref).
 
 [`ZeroTangent`](@ref) for the case that there is no relationship between the primal output and the primal input.
-[`NoTangent`](@ref) for the case that conceptually the tangent space don't exist.
+[`NoTangent`](@ref) for the case where conceptually the tangent space doesn't exist.
 e.g. what is the Tangent to a String or an index: those can't be perturbed.
 
-See [FAQ on difference between `ZeroTangent` and `NoTangent`](@ref faq_abstract_zero).
+See [FAQ on the difference between `ZeroTangent` and `NoTangent`](@ref faq_abstract_zero).
 At the end of the day it doesn't matter too much if you get them wrong.
 `NoTangent` and `ZeroTangent` more or less act identically.
 
 ### `Tuple`s and `NamedTuple`s become `Tangent{T}`s
 Zygote uses `Tuple`s and `NamedTuple`s to represent the structural tangents for `Tuple`s and `struct`s respectively.
-ChainRules core provides a generic `Tangent{T}`(@ref Tangent) to represent the structural tangent of a primal type `T`.
+ChainRules core provides a generic [`Tangent{T}`](@ref Tangent) to represent the structural tangent of a primal type `T`.
 It takes positional arguments if representing tangent for a `Tuple`.
-Or keyword argument to represent the tangent for a `struct`.
+Or keyword argument to represent the tangent for a `struct` or a `NamedTuple`.
 When representing a `struct` you only need to list the nonzero fields -- any not given are implicit considered to be [`ZeroTangent`](@ref).
 
 When we say structural tangent we mean tangent types that are based only on the structure of the primal.
@@ -84,7 +84,7 @@ For more details see the the [design docs on the many tangent types](@ref manyty
 Rules that need to call back into the AD system, e.g, for higher order functions like `map(f, xs)`, need to be changed.
 In `ZygoteRules` you can use `ZygoteRules.pullback` or `ZygoteRules._pullback`, which will always result in calling into Zygote.
 Since ChainRules is AD agnostic, you can't do that.
-Instead you use a [`RuleConfig`](@ref) to specify requirements of an AD system e.g `::RuleConfig{>:CanReverseMode}` work for Zygote,
+Instead you use a [`RuleConfig`](@ref) to specify requirements of an AD system e.g `::RuleConfig{>:HasReverseMode}` work for Zygote,
 and then use [`rrule_via_ad`](@ref).
 
 See the [docs on calling back into AD](@ref config) for more details.
@@ -92,16 +92,16 @@ See the [docs on calling back into AD](@ref config) for more details.
 ## Consider adding some thunks
 
 A feature ChainRulesCore offers that ZygoteRules doesn't is support for thunks.
-Where work is delayed until it is needed, and avoided if it never is.
+Thunks delay work until it is needed, and avoid it if it never is.
 See docs on [`@thunk`](@ref), [`Thunk`](@ref), [`InplaceableThunk`](@ref).
 
-You don't have to though.
+You don't have to use thunks, though.
 It is easy to go overboard with using thunks.
 
 ## Testing Changes
 
-One of the advantages of using ChainRules is that you can easily and robustly test it with [ChainRulesTestUtils.jl](https://juliadiff.org/ChainRulesTestUtils.jl/stable/).
-This both uses finite differencing to test accuracy of derivative, as well as checking the correctness of the API.
+One of the advantages of using ChainRules is that you can easily and robustly test your rules with [ChainRulesTestUtils.jl](https://juliadiff.org/ChainRulesTestUtils.jl/stable/).
+This uses finite differencing to test the accuracy of derivative, as well as checks the correctness of the API.
 It should catch anything you might have gotten wrong referred to in this page.
 
 The test for the above example is `test_rrule(f, 2.5, Foo(9.9, 7.2), 31.0)`.
@@ -109,7 +109,7 @@ You can see it looks a lot like an example call to `rrule`, just with the prefix
 
 ## `@nograd` becomes `@non_differentiable`
 Probably more or less with no changes.
-[`@non_differentiable`](@ref) also lets you specify a signature.
+[`@non_differentiable`](@ref) also lets you specify a signature in case you want to restrict non-differentiability to a certain subset of argument types.
 
 ## No such thing a `literal_getproperty`
 That is just `getproperty`, it takes `Symbol`.
@@ -117,14 +117,14 @@ It should constant-fold.
 It likely doesn't though as Zygote doesn't play nice with the optimizer.
 
 ## Take embedded spaces and types seriously
-Traditionally Zygote has taken a very laissez faire attitude towards types and mathematical spaces.
-Sometimes treating `Real`s as embedded in the `Complex` plane; some time not.
-Sometimes treating sparse and structuredly-sparse matrix as embedded in the space of dense matrixes.
+Traditionally Zygote has taken a very laissez-faire attitude towards types and mathematical spaces.
+Sometimes treating `Real`s as embedded in the `Complex` plane; sometimes not.
+Sometimes treating sparse and structuredly-sparse matrix as embedded in the space of dense matrices.
 Writing rules that apply to any `Array{T}` which perhaps are only applicable for `Array{<:Real}` and not so much for `Array{Quaternion}`.
 Traditionally ChainRules takes a much more considered approach.
 
 See for example our [docs on how to handle complex numbers](@ref complexfunctions) correctly.
-(The outcome of several long long long discussions with a number of expert in our community)
+(The outcome of several long long long discussions with a number of experts in our community)
 
 Now, I am not here to tell you what to do in your package, but this is a good time to reconsider how seriously you take these things in the rules you are converting.
 

--- a/docs/src/design/many_differentials.md
+++ b/docs/src/design/many_differentials.md
@@ -1,4 +1,4 @@
-# Design Notes: The many-to-many relationship between differential types and primal types.
+# [Design Notes: The many-to-many relationship between differential types and primal types](@id manytypes)
 
 ChainRules has a system where one primal type (the type having its derivative taken) can have multiple possible differential types (the type of the derivative); and where one differential type can correspond to multiple primal types.
 This is in-contrast to the Swift AD efforts, which has one differential type per primal type (Swift uses the term associated tangent type, rather than differential type).


### PR DESCRIPTION
Motivated by https://github.com/SciML/SciMLBase.jl/issues/69
(and the upcoming release of Diffractor which IAUI will require the use of ChainRulesCore rather than ZygoteRules)

[Docs preview](https://juliadiff.org/ChainRulesCore.jl/previews/PR378/converting_zygoterules.html)