### PR TITLE
WIP: `projector` implementation (returning a closure)

### DIFF
--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -10,7 +10,7 @@ export RuleConfig, HasReverseMode, NoReverseMode, HasForwardsMode, NoForwardsMod
 export frule_via_ad, rrule_via_ad
 # definition helper macros
 export @non_differentiable, @scalar_rule, @thunk, @not_implemented
-export canonicalize, extern, unthunk  # differential operations
+export canonicalize, extern, unthunk, project  # differential operations
 export add!!  # gradient accumulation operations
 # differentials
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -26,6 +26,7 @@ include("differentials/notimplemented.jl")
 
 include("differential_arithmetic.jl")
 include("accumulation.jl")
+include("projection.jl")
 
 include("config.jl")
 include("rules.jl")

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -10,7 +10,7 @@ export RuleConfig, HasReverseMode, NoReverseMode, HasForwardsMode, NoForwardsMod
 export frule_via_ad, rrule_via_ad
 # definition helper macros
 export @non_differentiable, @scalar_rule, @thunk, @not_implemented
-export canonicalize, extern, unthunk, project  # differential operations
+export canonicalize, extern, unthunk, projector  # differential operations
 export add!!  # gradient accumulation operations
 # differentials
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk

--- a/src/differentials/abstract_zero.jl
+++ b/src/differentials/abstract_zero.jl
@@ -27,6 +27,7 @@ Base.:/(z::AbstractZero, ::Any) = z
 Base.convert(::Type{T}, x::AbstractZero) where T <: Number = zero(T)
 
 Base.getindex(z::AbstractZero, k) = z
+Base.getproperty(z::AbstractZero, f::Symbol) = z
 
 """
     ZeroTangent() <: AbstractZero

--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -37,6 +37,8 @@ Base.imag(a::AbstractThunk) = imag(unthunk(a))
 Base.Complex(a::AbstractThunk) = Complex(unthunk(a))
 Base.Complex(a::AbstractThunk, b::AbstractThunk) = Complex(unthunk(a), unthunk(b))
 
+Base.getproperty(a::AbstractThunk, f::Symbol) = f === :f ? getfield(a, f) : getproperty(unthunk(a), f)
+
 Base.mapreduce(f, op, a::AbstractThunk; kws...) = mapreduce(f, op, unthunk(a); kws...)
 function Base.mapreduce(f, op, itr, a::AbstractThunk; kws...)
     return mapreduce(f, op, itr, unthunk(a); kws...)

--- a/src/differentials/thunks.jl
+++ b/src/differentials/thunks.jl
@@ -37,8 +37,6 @@ Base.imag(a::AbstractThunk) = imag(unthunk(a))
 Base.Complex(a::AbstractThunk) = Complex(unthunk(a))
 Base.Complex(a::AbstractThunk, b::AbstractThunk) = Complex(unthunk(a), unthunk(b))
 
-Base.getproperty(a::AbstractThunk, f::Symbol) = f === :f ? getfield(a, f) : getproperty(unthunk(a), f)
-
 Base.mapreduce(f, op, a::AbstractThunk; kws...) = mapreduce(f, op, unthunk(a); kws...)
 function Base.mapreduce(f, op, itr, a::AbstractThunk; kws...)
     return mapreduce(f, op, itr, unthunk(a); kws...)
@@ -190,6 +188,8 @@ end
 
 @inline unthunk(x::Thunk) = x.f()
 
+Base.getproperty(a::Thunk, f::Symbol) = f === :f ? getfield(a, f) : getproperty(unthunk(a), f)
+
 Base.show(io::IO, x::Thunk) = print(io, "Thunk($(repr(x.f)))")
 
 """
@@ -210,6 +210,8 @@ struct InplaceableThunk{T<:Thunk,F} <: AbstractThunk
 end
 
 unthunk(x::InplaceableThunk) = unthunk(x.val)
+
+Base.getproperty(a::InplaceableThunk, f::Symbol) = f in (:val, :add!) ? getfield(a, f) : getproperty(unthunk(a), f)
 
 function Base.show(io::IO, x::InplaceableThunk)
     return print(io, "InplaceableThunk($(repr(x.val)), $(repr(x.add!)))")

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -17,6 +17,8 @@ project(x, dx) = project(typeof(x), x, dx)
 # Number-types
 project(::Type{T}, x::T, dx::T) where {T<:Real} = dx
 
+project(::Type{T}, x::T, dx::Complex) where {T<:Real} = real(dx)
+
 project(::Type{T}, x::T, dx::AbstractZero) where {T<:Real} = zero(x)
 
 project(::Type{T}, x::T, dx::AbstractThunk) where {T<:Real} = project(x, unthunk(dx))

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -16,7 +16,6 @@ projector(x) = projector(typeof(x), x)
 
 # fallback (structs)
 function projector(::Type{T}, x::T) where T
-    println("to Any, T=$T")
     project(dx::T) = dx
     project(dx::AbstractZero) = zero(x)
     project(dx::AbstractThunk) = project(unthunk(dx))
@@ -25,7 +24,6 @@ end
 
 # Numbers
 function projector(::Type{T}, x::T) where {T<:Real}
-    println("to Real")
     project(dx::Real) = T(dx)
     project(dx::Number) = T(real(dx)) # to avoid InexactError
     project(dx::AbstractZero) = zero(x)
@@ -33,7 +31,6 @@ function projector(::Type{T}, x::T) where {T<:Real}
     return project
 end
 function projector(::Type{T}, x::T) where {T<:Number}
-    println("to Number")
     project(dx::Number) = T(dx)
     project(dx::AbstractZero) = zero(x)
     project(dx::AbstractThunk) = project(unthunk(dx))
@@ -42,7 +39,6 @@ end
 
 # Arrays
 function projector(::Type{Array{T, N}}, x::Array{T, N}) where {T, N}
-    println("to Array")
     element = zero(eltype(x))
     sizex = size(x)
     project(dx::Array{T, N}) = dx # identity
@@ -55,14 +51,12 @@ end
 
 # Tangent
 function projector(::Type{<:Tangent}, x::T) where {T}
-    println("to Tangent")
     project(dx) = Tangent{T}(; ((k, getproperty(dx, k)) for k in fieldnames(T))...)
     return project
 end
 
 # Diagonal
 function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal) where {V}
-    println("to Diagonal")
     projV = projector(V, diag(x))
     project(dx::AbstractMatrix) = Diagonal(projV(diag(dx)))
     project(dx::Tangent) = Diagonal(projV(dx.diag))
@@ -73,7 +67,6 @@ end
 
 # Symmetric
 function projector(::Type{<:Symmetric{<:Any, M}}, x::Symmetric) where {M}
-    println("to Symetric")
     projM = projector(M, parent(x))
     uplo = Symbol(x.uplo)
     project(dx::AbstractMatrix) = Symmetric(projM(dx), uplo)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -39,11 +39,11 @@ end
 
 # Arrays
 function projector(::Type{Array{T, N}}, x::Array{T, N}) where {T, N}
-    element = zero(eltype(x))
     sizex = size(x)
+    projT = projector(zero(T))
     project(dx::Array{T, N}) = dx # identity
     project(dx::AbstractArray) = project(collect(dx)) # from Diagonal
-    project(dx::Array) = projector(element).(dx) # from different element type
+    project(dx::Array) = projT.(dx) # from different element type
     project(dx::AbstractZero) = zeros(T, sizex...)
     project(dx::AbstractThunk) = project(unthunk(dx))
     return project

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -3,13 +3,13 @@ using LinearAlgebra: Diagonal, diag
 """
     projector([T::Type], x)
 
-"project" `dx` onto type `T` such that it is the same size as `x`. If `T` is not provided,
-it is assumed to be the type of `x`.
+Returns a `project(dx)` closure which maps `dx` onto type `T`, such that it is the
+same size as `x`. If `T` is not provided, it is assumed to be the type of `x`.
 
-It's necessary to have `x` to ensure that it's possible to projector e.g. `AbstractZero`s
+It's necessary to have `x` to ensure that it's possible to project e.g. `AbstractZero`s
 onto `Array`s -- this wouldn't be possible with type information alone because the neither
 `AbstractZero`s nor `T` know what size of `Array` to produce.
-""" # TODO change docstring to reflect projecor returns a closure
+"""
 function projector end
 
 projector(x) = projector(typeof(x), x)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -1,15 +1,18 @@
 using LinearAlgebra: Diagonal, diag
 
 """
-    project(T::Type, x, dx)
+    project([T::Type], x, dx)
 
-"project" `dx` onto type `T` such that it is the same size as `x`.
+"project" `dx` onto type `T` such that it is the same size as `x`. If `T` is not provided,
+it is assumed to be the type of `x`.
 
 It's necessary to have `x` to ensure that it's possible to project e.g. `AbstractZero`s
 onto `Array`s -- this wouldn't be possible with type information alone because the neither
 `AbstractZero`s nor `T` know what size of `Array` to produce.
 """
 function project end
+
+project(x, dx) = project(typeof(x), x, dx)
 
 # Number-types
 project(::Type{T}, x::T, dx::T) where {T<:Real} = dx

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -1,0 +1,55 @@
+using LinearAlgebra: Diagonal, diag
+
+"""
+    project(T::Type, x, dx)
+
+"project" `dx` onto type `T` such that it is the same size as `x`.
+
+It's necessary to have `x` to ensure that it's possible to project e.g. `AbstractZero`s
+onto `Array`s -- this wouldn't be possible with type information alone because the neither
+`AbstractZero`s nor `T` know what size of `Array` to produce.
+"""
+function project end
+
+# Number-types
+project(::Type{T}, x::T, dx::T) where {T<:Real} = dx
+
+project(::Type{T}, x::T, dx::AbstractZero) where {T<:Real} = zero(x)
+
+project(::Type{T}, x::T, dx::AbstractThunk) where {T<:Real} = project(x, unthunk(dx))
+
+
+
+# Arrays
+project(::Type{Array{T, N}}, x::Array{T, N}, dx::Array{T, N}) where {T<:Real, N} = dx
+
+project(::Type{<:Array{T}}, x::Array, dx::Array) where {T} = project.(Ref(T), x, dx)
+
+function project(::Type{T}, x::Array, dx::AbstractArray) where {T<:Array}
+    return project(T, x, collect(dx))
+end
+
+function project(::Type{<:Array{T}}, x::Array, dx::AbstractZero) where {T}
+    return project.(Ref(T), x, Ref(dx))
+end
+
+
+
+# Diagonal
+function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::AbstractMatrix) where {V}
+    return Diagonal(project(V, diag(x), diag(dx)))
+end
+
+function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::Composite) where {V}
+    return Diagonal(project(V, diag(x), dx.diag))
+end
+
+function project(::Type{<:Composite}, x::Diagonal, dx::Diagonal)
+    return Composite{typeof(x)}(diag=diag(dx))
+end
+
+
+
+# One use for this functionality is to make it easy to define addition between two different
+# representations of the same tangent. This also makes it clear that the 
+Base.:(+)(x::Composite{<:Diagonal}, y::Diagonal) = x + project(typeof(x), x, y)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -40,16 +40,16 @@ function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::AbstractMatrix) 
     return Diagonal(project(V, diag(x), diag(dx)))
 end
 
-function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::Composite) where {V}
+function project(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::Tangent) where {V}
     return Diagonal(project(V, diag(x), dx.diag))
 end
 
-function project(::Type{<:Composite}, x::Diagonal, dx::Diagonal)
-    return Composite{typeof(x)}(diag=diag(dx))
+function project(::Type{<:Tangent}, x::Diagonal, dx::Diagonal)
+    return Tangent{typeof(x)}(diag=diag(dx))
 end
 
 
 
 # One use for this functionality is to make it easy to define addition between two different
 # representations of the same tangent. This also makes it clear that the 
-Base.:(+)(x::Composite{<:Diagonal}, y::Diagonal) = x + project(typeof(x), x, y)
+Base.:(+)(x::Tangent{<:Diagonal}, y::Diagonal) = x + project(typeof(x), x, y)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -14,9 +14,9 @@ function projector end
 
 projector(x) = projector(typeof(x), x)
 
-# fallback
+# fallback (structs)
 function projector(::Type{T}, x::T) where T
-    println("to Any")
+    println("to Any, T=$T")
     project(dx::T) = dx
     project(dx::AbstractZero) = zero(x)
     project(dx::AbstractThunk) = project(unthunk(dx))
@@ -71,3 +71,14 @@ function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal) where {V}
     return project
 end
 
+# Symmetric
+function projector(::Type{<:Symmetric{<:Any, M}}, x::Symmetric) where {M}
+    println("to Symetric")
+    projM = projector(M, parent(x))
+    uplo = Symbol(x.uplo)
+    project(dx::AbstractMatrix) = Symmetric(projM(dx), uplo)
+    project(dx::Tangent) = Symmetric(projM(dx.data), uplo)
+    project(dx::AbstractZero) = Symmetric(projM(dx), uplo)
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
+end

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -1,9 +1,9 @@
 using LinearAlgebra: Diagonal, diag
 
 """
-    projector([T::Type], x, dx)
+    projector([T::Type], x)
 
-"projector" `dx` onto type `T` such that it is the same size as `x`. If `T` is not provided,
+"project" `dx` onto type `T` such that it is the same size as `x`. If `T` is not provided,
 it is assumed to be the type of `x`.
 
 It's necessary to have `x` to ensure that it's possible to projector e.g. `AbstractZero`s
@@ -12,55 +12,62 @@ onto `Array`s -- this wouldn't be possible with type information alone because t
 """ # TODO change docstring to reflect projecor returns a closure
 function projector end
 
-projector(x, dx) = projector(typeof(x), x, dx)
+projector(x) = projector(typeof(x), x)
 
-# identity
-projector(::Type{T}, x::T, dx::T) where T = identity
+# fallback
+function projector(::Type{T}, x::T) where T
+    println("to Any")
+    project(dx::T) = dx
+    project(dx::AbstractZero) = zero(x)
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
+end
 
-### AbstractZero
-projector(::Type{T}, x::T, dx::AbstractZero) where T = _ -> zero(x)
-
-### AbstractThunk
-projector(::Type{T}, x::T, dx::AbstractThunk) where T = projector(x, unthunk(dx))
-
-
-### Number-types
-projector(::Type{T}, x::T, dx::T2) where {T<:Number, T2<:Number} = dx -> T(dx)
-projector(::Type{T}, x::T, dx::Complex) where {T<:Real} = dx -> T(real(dx))
-
+# Numbers
+function projector(::Type{T}, x::T) where {T<:Real}
+    println("to Real")
+    project(dx::Real) = T(dx)
+    project(dx::Number) = T(real(dx)) # to avoid InexactError
+    project(dx::AbstractZero) = zero(x)
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
+end
+function projector(::Type{T}, x::T) where {T<:Number}
+    println("to Number")
+    project(dx::Number) = T(dx)
+    project(dx::AbstractZero) = zero(x)
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
+end
 
 # Arrays
-projector(::Type{Array{T, N}}, x::Array{T, N}, dx::Array{T, N}) where {T<:Real, N} = identity
-
-# for projector([Foo(0.0), Foo(0.0)], [ZeroTangent(), ZeroTangent()])
-projector(::Type{<:Array{T}}, x::Array, dx::Array) where {T} = projector.(Ref(T), x, dx) # TODO
-
-# for projector(rand(2, 2), Diagonal(rand(2)))
-function projector(::Type{T}, x::Array, dx::AbstractArray) where {T<:Array}
-    return projector(T, x, collect(dx))
+function projector(::Type{Array{T, N}}, x::Array{T, N}) where {T, N}
+    println("to Array")
+    element = zero(eltype(x))
+    project(dx::Array{T, N}) = dx # identity
+    project(dx::AbstractArray) = project(collect(dx)) # from Diagonal
+    project(dx::Array) = projector(element).(dx) # from different element type
+    project(dx::AbstractZero) = zero(x)
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
 end
 
-# for projector([Foo(0.0), Foo(0.0)], ZeroTangent())
-function projector(::Type{<:Array{T}}, x::Array, dx::AbstractZero) where {T}
-    return projector.(Ref(T), x, Ref(dx)) # TODO
+# Tangent
+function projector(::Type{<:Tangent}, x)
+    println("to Tangent")
+    keys = fieldnames(typeof(x))
+    project(dx) = Tangent{typeof(x)}(; ((k, getproperty(dx, k)) for k in keys)...)
+    return project
 end
 
-
-## Diagonal
-function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::AbstractMatrix) where {V}
+# Diagonal
+function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal) where {V}
+    println("to Diagonal")
     d = diag(x)
-    return dx -> Diagonal(projector(V, d, diag(dx)))
-end
-function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::Tangent) where {V}
-    d = diag(x)
-    return dx -> Diagonal(projector(V, d, dx.diag))
-end
-function projector(::Type{<:Diagonal{<:Any, V}}, x::Diagonal, dx::AbstractZero) where {V}
-    d = diag(x)
-    return dx -> Diagonal(projector(V, d, dx))
+    project(dx::AbstractMatrix) = Diagonal(projector(V, d)(diag(dx)))
+    project(dx::Tangent) = Diagonal(projector(V, d)(dx.diag))
+    project(dx::AbstractZero) = Diagonal(projector(V, d)(dx))
+    project(dx::AbstractThunk) = project(unthunk(dx))
+    return project
 end
 
-function projector(::Type{<:Tangent}, x::Diagonal, dx::Diagonal)
-    T = typeof(x)
-    return dx -> Tangent{T}(diag=diag(dx))
-end

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -58,6 +58,16 @@ Base.zero(::Type{Fred}) = Fred(0.0)
         @test diagfreds == projector(diagfreds)(Diagonal([Fred(1.0), Fred(4.0)]))
     end
 
+    @testset "to Tangent" begin
+        @test Tangent{Fred}(; a = 3.2,) == projector(Tangent, Fred(3.2))(Fred(3.2))
+        @test Tangent{Fred}(; a = ZeroTangent(),) == projector(Tangent, Fred(3.2))(ZeroTangent())
+        @test Tangent{Fred}(; a = ZeroTangent(),) == projector(Tangent, Fred(3.2))(@thunk(ZeroTangent()))
+
+        @test projector(Tangent, Diagonal(zeros(2)))(Diagonal([1.0f0, 2.0f0])) isa Tangent
+        @test projector(Tangent, Diagonal(zeros(2)))(ZeroTangent()) isa Tangent
+        @test projector(Tangent, Diagonal(zeros(2)))(@thunk(ZeroTangent())) isa Tangent
+    end
+
     @testset "to Diagonal" begin
         d_F64 = Diagonal([0.0, 0.0])
         d_F32 = Diagonal([0.0f0, 0.0f0])
@@ -92,15 +102,13 @@ Base.zero(::Type{Fred}) = Fred(0.0)
         @test d_F64 == projector(d_F64)(Tangent{Diagonal}(;diag=[ZeroTangent(), @thunk(ZeroTangent())]))
     end
 
-    @testset "to Tangent" begin
-        @test Tangent{Fred}(; a = 3.2,) == projector(Tangent, Fred(3.2))(Fred(3.2))
-        @test Tangent{Fred}(; a = ZeroTangent(),) == projector(Tangent, Fred(3.2))(ZeroTangent())
-        @test Tangent{Fred}(; a = ZeroTangent(),) == projector(Tangent, Fred(3.2))(@thunk(ZeroTangent()))
+    @testset "to Symmetric" begin
+        data = [1.0 2; 3 4]
+        @test Symmetric(data) == projector(Symmetric(data))(data)
+        @test Symmetric(data, :L) == projector(Symmetric(data, :L))(data)
+        @test Symmetric(Diagonal(data)) == projector(Symmetric(data))(Diagonal(diag(data)))
 
-        @test projector(Tangent, Diagonal(zeros(2)))(Diagonal([1.0f0, 2.0f0])) isa Tangent
-        @test projector(Tangent, Diagonal(zeros(2)))(ZeroTangent()) isa Tangent
-        @test projector(Tangent, Diagonal(zeros(2)))(@thunk(ZeroTangent())) isa Tangent
+        @test Symmetric(zeros(2, 2)) == projector(Symmetric(data))(ZeroTangent())
+        @test Symmetric(zeros(2, 2)) == projector(Symmetric(data))(@thunk(ZeroTangent()))
     end
-
-    # how to project to Upper/Lower Symmetric
 end

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -1,10 +1,81 @@
-@testset "projection" begin
-    @testset "Number types" begin
-        @test 3.2 == project(1.0, 3.2)
-        @test 3.2 == project(1.0, 3.2 + 3im)
-        @test 3.2f0 == project(Float32, 1.0f0, 3.2 - 3im)
+struct Foo
+    a::Float64
+end
 
-        @test 0.0 == project(1.1, ZeroTangent())
-        @test 3.2 == project(1.0, @thunk(3.2))
+Base.zero(::Foo) = Foo(0.0)
+Base.zero(::Type{Foo}) = "F0"
+
+@testset "projection" begin
+
+    #identity
+    @test Foo(1.2) == project(Foo(-0.2), Foo(1.2))
+    @test 3.2 == project(1.0, 3.2)
+    @test 2.0 + 0.0im == project(1.0im, 2.0)
+
+    @testset "From AbstractZero" begin
+        @testset "to numbers" begin
+            @test 0.0 == project(1.1, ZeroTangent())
+            @test 0.0f0 == project(1.1f0, ZeroTangent())
+        end
+
+        @testset "to arrays (dense and structured)" begin
+            @test zeros(2, 2) == project([1.0 2; 3 4], ZeroTangent())
+            @test Diagonal(zeros(2)) == project(Diagonal([1.0, 4]), ZeroTangent())
+            @test Diagonal(zeros(ComplexF64, 2)) == project(Diagonal([1.0 + 0im, 4]), ZeroTangent())
+        end
+
+        @testset "to structs" begin
+            @test Foo(0.0) == project(Foo(3.2), ZeroTangent())
+        end
+
+        @testset "to arrays of structs" begin
+            @test [Foo(0.0), Foo(0.0)] == project([Foo(0.0), Foo(0.0)], ZeroTangent())
+            @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), ZeroTangent())
+        end
     end
+
+    @testset "From AbstractThunk" begin
+        @test 3.2 == project(1.0, @thunk(3.2))
+        @test Foo(3.2) == project(Foo(-0.2), @thunk(Foo(3.2)))
+        @test zeros(2) == project([1.0, 2.0], @thunk(ZeroTangent()))
+        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), @thunk(ZeroTangent()))
+    end
+
+    @testset "To number types" begin
+        @testset "to subset" begin
+            @test 3.2 == project(1.0, 3.2 + 3im)
+            @test 3.2f0 == project(1.0f0, 3.2)
+            @test 3.2f0 == project(1.0f0, 3.2 - 3im)
+        end
+
+        @testset "to superset" begin
+            @test 2.0 + 0.0im == project(2.0 + 1.0im, 2.0)
+            @test 2.0 == project(2.0, 2.0f0)
+        end
+    end
+
+    @testset "To Arrays" begin
+        # change eltype
+        @test [1.0 2.0; 3.0 4.0] == project(zeros(2, 2), [1.0 2.0; 3.0 4.0])
+        @test [1.0f0 2; 3 4] == project(zeros(Float32, 2, 2), [1.0 2; 3 4])
+
+        # from a structured array
+        @test [1.0 0; 0 4] == project(zeros(2, 2), Diagonal([1.0, 4]))
+
+        # from an array of specials
+        @test [Foo(0.0), Foo(0.0)] == project([Foo(0.0), Foo(0.0)], [ZeroTangent(), ZeroTangent()])
+    end
+
+    @testset "Diagonal" begin
+        d = Diagonal([1.0, 4.0])
+        t = Tangent{Diagonal}(;diag=[1.0, 4.0])
+        @test d == project(d, [1.0 2; 3 4])
+        @test d == project(d, t)
+        @test project(Tangent, d, d) isa Tangent
+
+        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), Diagonal([ZeroTangent(), ZeroTangent()]))
+        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), @thunk(ZeroTangent()))
+    end
+
+    # how to project to Upper/Lower Symmetric
 end

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -1,14 +1,14 @@
-struct Foo
+struct Fred
     a::Float64
 end
 
-Base.zero(::Foo) = Foo(0.0)
-Base.zero(::Type{Foo}) = "F0"
+Base.zero(::Fred) = Fred(0.0)
+Base.zero(::Type{Fred}) = "F0"
 
 @testset "projection" begin
 
     #identity
-    @test Foo(1.2) == project(Foo(-0.2), Foo(1.2))
+    @test Fred(1.2) == project(Fred(-0.2), Fred(1.2))
     @test 3.2 == project(1.0, 3.2)
     @test 2.0 + 0.0im == project(1.0im, 2.0)
 
@@ -25,20 +25,20 @@ Base.zero(::Type{Foo}) = "F0"
         end
 
         @testset "to structs" begin
-            @test Foo(0.0) == project(Foo(3.2), ZeroTangent())
+            @test Fred(0.0) == project(Fred(3.2), ZeroTangent())
         end
 
         @testset "to arrays of structs" begin
-            @test [Foo(0.0), Foo(0.0)] == project([Foo(0.0), Foo(0.0)], ZeroTangent())
-            @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), ZeroTangent())
+            @test [Fred(0.0), Fred(0.0)] == project([Fred(0.0), Fred(0.0)], ZeroTangent())
+            @test Diagonal([Fred(0.0), Fred(0.0)]) == project(Diagonal([Fred(3.2,), Fred(4.2)]), ZeroTangent())
         end
     end
 
     @testset "From AbstractThunk" begin
         @test 3.2 == project(1.0, @thunk(3.2))
-        @test Foo(3.2) == project(Foo(-0.2), @thunk(Foo(3.2)))
+        @test Fred(3.2) == project(Fred(-0.2), @thunk(Fred(3.2)))
         @test zeros(2) == project([1.0, 2.0], @thunk(ZeroTangent()))
-        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), @thunk(ZeroTangent()))
+        @test Diagonal([Fred(0.0), Fred(0.0)]) == project(Diagonal([Fred(3.2,), Fred(4.2)]), @thunk(ZeroTangent()))
     end
 
     @testset "To number types" begin
@@ -63,7 +63,7 @@ Base.zero(::Type{Foo}) = "F0"
         @test [1.0 0; 0 4] == project(zeros(2, 2), Diagonal([1.0, 4]))
 
         # from an array of specials
-        @test [Foo(0.0), Foo(0.0)] == project([Foo(0.0), Foo(0.0)], [ZeroTangent(), ZeroTangent()])
+        @test [Fred(0.0), Fred(0.0)] == project([Fred(0.0), Fred(0.0)], [ZeroTangent(), ZeroTangent()])
     end
 
     @testset "Diagonal" begin
@@ -73,8 +73,8 @@ Base.zero(::Type{Foo}) = "F0"
         @test d == project(d, t)
         @test project(Tangent, d, d) isa Tangent
 
-        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), Diagonal([ZeroTangent(), ZeroTangent()]))
-        @test Diagonal([Foo(0.0), Foo(0.0)]) == project(Diagonal([Foo(3.2,), Foo(4.2)]), @thunk(ZeroTangent()))
+        @test Diagonal([Fred(0.0), Fred(0.0)]) == project(Diagonal([Fred(3.2,), Fred(4.2)]), Diagonal([ZeroTangent(), ZeroTangent()]))
+        @test Diagonal([Fred(0.0), Fred(0.0)]) == project(Diagonal([Fred(3.2,), Fred(4.2)]), @thunk(ZeroTangent()))
     end
 
     # how to project to Upper/Lower Symmetric

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -1,0 +1,3 @@
+@testset "projection" begin
+
+end

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -1,3 +1,10 @@
 @testset "projection" begin
+    @testset "Number types" begin
+        @test 3.2 == project(1.0, 3.2)
+        @test 3.2 == project(1.0, 3.2 + 3im)
+        @test 3.2f0 == project(Float32, 1.0f0, 3.2 - 3im)
 
+        @test 0.0 == project(1.1, ZeroTangent())
+        @test 3.2 == project(1.0, @thunk(3.2))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ using Test
     end
 
     include("accumulation.jl")
+    include("projection.jl")
 
     include("rules.jl")
     include("rule_definition_tools.jl")


### PR DESCRIPTION
Alternative to https://github.com/JuliaDiff/ChainRulesCore.jl/pull/380.

Some observations (comments welcome):
- while there is some repetition, this was less fiddly to write and test than #380. Hopefully it is also easier to read.
- returning the closure means we don't have to carry the primal type in the pullback anymore (apart from in the fallback case). cc @CarloLucibello
- we can compose these, see e.g. `projector(::Diagonal)`, where we create a `projV` to project the vector representing the diagonal. cc @mcabbott

I imagine we also want to add some extra requirements to ChainRulesTestUtils, to make sure that the rules always return a correct differential. Something like `_is_appropriate(primal, tangent)` where the `unthunk(tangent)` must either be the same type as the primal, a `Tangent`, or an `AbstractZero`.