### PR TITLE
Get rid of useless broadcasting

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -56,7 +56,7 @@ derivative/setup expressions.
 This macro assumes complex functions are holomorphic. In general, for non-holomorphic
 functions, the `frule` and `rrule` must be defined manually.
 
-If the derivative is one, (e.g. for identity functions) `true` can be used as the most 
+If the derivative is one, (e.g. for identity functions) `true` can be used as the most
 general multiplicative identity.
 
 The `@setup` argument can be elided if no setup code is need. In other
@@ -249,11 +249,11 @@ function propagation_expr(Δs, ∂s, _conj=false, proj=identity)
     summed_∂_mul_Δs = if n∂s > 1
         # Explicit multiplication is only performed for the first pair
         # of partial and gradient.
-        init_expr = :((*).($(_∂s[1]), $(Δs[1])))
+        init_expr = :(*($(_∂s[1]), $(Δs[1])))
 
         # Apply `muladd` iteratively.
         foldl(Iterators.drop(zip(_∂s, Δs), 1); init=init_expr) do ex, (∂s_i, Δs_i)
-            :((muladd).($∂s_i, $Δs_i, $ex))
+            :(muladd($∂s_i, $Δs_i, $ex))
         end
     else
         # Note: we don't want to do broadcasting with only 1 multiply (no `+`),

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -244,24 +244,13 @@ function propagation_expr(Δs, ∂s, _conj=false, proj=identity)
             esc(∂s_i)
         end
     end
-    n∂s = length(_∂s)
 
-    summed_∂_mul_Δs = if n∂s > 1
-        # Explicit multiplication is only performed for the first pair
-        # of partial and gradient.
-        init_expr = :(*($(_∂s[1]), $(Δs[1])))
-
-        # Apply `muladd` iteratively.
-        foldl(Iterators.drop(zip(_∂s, Δs), 1); init=init_expr) do ex, (∂s_i, Δs_i)
-            :(muladd($∂s_i, $Δs_i, $ex))
-        end
-    else
-        # Note: we don't want to do broadcasting with only 1 multiply (no `+`),
-        # because some arrays overload multiply with scalar. Avoiding
-        # broadcasting saves compilation time.
-        :($(_∂s[1]) * $(Δs[1]))
+    # Apply `muladd` iteratively.
+    # Explicit multiplication is only performed for the first pair of partial and gradient.
+    init_expr = :(*($(_∂s[1]), $(Δs[1])))
+    summed_∂_mul_Δs = foldl(Iterators.drop(zip(_∂s, Δs), 1); init=init_expr) do ex, (∂s_i, Δs_i)
+        :(muladd($∂s_i, $Δs_i, $ex))
     end
-
     return :($proj($summed_∂_mul_Δs))
 end
 


### PR DESCRIPTION
This broadcasting is causing a fair bit of trouble for nested AD in Diffractor, so I'd like to disable it. I believe the original purpose here was to enable chunked forwarddiff for ForwardDiff2, but since that is abandoned, I do not believe there are any current users. Diffractor will also need some sort of accommodation here for chunked forward mode, but it is unlikely to be broadcasting.