### PR TITLE
Fix printing of Tangent{T} with empty backing

### DIFF
--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -60,8 +60,12 @@ function Base.show(io::IO, comp::Tangent{P}) where P
     print(io, "Tangent{")
     show(io, P)
     print(io, "}")
-    # allow Tuple or NamedTuple `show` to do the rendering of brackets etc
-    show(io, backing(comp))
+    if isempty(backing(comp))
+        print(io, "()")  # so it doesn't show `NamedTuple()`
+    else
+        # allow Tuple or NamedTuple `show` to do the rendering of brackets etc
+        show(io, backing(comp))
+    end
 end
 
 Base.convert(::Type{<:NamedTuple}, comp::Tangent{<:Any, <:NamedTuple}) = backing(comp)

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -325,6 +325,8 @@ end
             r"^Tangent{Tuple{Int64,\s?Int64}}\(1,\s?2\)$",
             repr(Tangent{Tuple{Int64,Int64}}(1, 2)),
         )
+
+        @test repr(Tangent{Foo}()) == "Tangent{Foo}()"
     end
 
     @testset "internals" begin


### PR DESCRIPTION
`Tangent{Foo}()` was printing as `Tangent{Foo}NamedTuple()"`