### PR TITLE
Add 3rd argument to InplaceableThunk

### DIFF
--- a/src/accumulation.jl
+++ b/src/accumulation.jl
@@ -12,8 +12,8 @@ add!!(x, y) = x + y
 The specialization of `add!!` for [`InplaceableThunk`](@ref) promises to only call
 `t.add!` on `x` if `x` is suitably mutable; otherwise it will be out of place.
 """
-function add!!(x, t::InplaceableThunk)
-    return if is_inplaceable_destination(x)
+function add!!(x, t::InplaceableThunk{T,F,S}) where {T,F,S}
+    return if x isa S && is_inplaceable_destination(x)
         if !debug_mode()
             t.add!(x)
         else


### PR DESCRIPTION
An approach to https://github.com/JuliaDiff/ChainRulesCore.jl/issues/411

This lets you specify when it will be safe to apply the in-place rule. `is_inplaceable_destination` is not sufficient, because it must accept Vector{Float64}, but I can't write complex numbers into that. 

The safer rule would then look like this. If A is reals & B is complex, and dA is real, then this ought to reject `mul!`:
```
function rrule(
    ::typeof(*),
    A::AbstractVecOrMat{<:CommutativeMulNumber},
    B::AbstractVecOrMat{<:CommutativeMulNumber},
)
    Y = A * B
    TY = eltype(Y)
    function times_pullback(ȳ)
        Ȳ = unthunk(ȳ)
        return (
            NoTangent(),
            InplaceableThunk(
                @thunk(Ȳ * B'),
                X̄ -> mul!(X̄, Ȳ, B', true, true),
                StridedArray{TY}
            ),
            InplaceableThunk(
                @thunk(A' * Ȳ),
                X̄ -> mul!(X̄, A', Ȳ, true, true),
                StridedArray{TY}
            )
        )
    end
    return Y, times_pullback
end
```