### PR TITLE
Fix indent of note in Introduction doc

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -71,7 +71,7 @@ even though they are not present in seperate forms in the code.
     While `rrule` takes only the arguments to the original function (the primal arguments) and returns a function (the pullback) that operates with the derivative information, the `frule` does it all at once.
     This is because the `frule` fuses the primal computation and the pushforward.
     This is an optimization that allows `frule`s to contain single large operations that perform both the primal computation and the pushforward at the same time (for example solving an ODE).
-This operation is only possible in forward mode (where `frule` is used) because the derivative information needed by the pushforward available with the `frule` is invoked -- it is about the primal function's inputs.
+    This operation is only possible in forward mode (where `frule` is used) because the derivative information needed by the pushforward available with the `frule` is invoked -- it is about the primal function's inputs.
     In contrast, in reverse mode the derivative information needed by the pullback is about the primal function's output.
     Thus the reverse mode returns the pullback function which the caller (usually an AD system) keeps hold of until derivative information about the output is available.
 


### PR DESCRIPTION
Missing indent was splitting half the note "Why `rrule` returns a pullback ..."
outside the note box