### PR TITLE
use hasproperty, not hasfield for ProjectTo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -3,7 +3,7 @@ using Base.Broadcast: broadcasted, Broadcasted, broadcastable, materialize, mate
 using Base.Meta
 using LinearAlgebra
 using SparseArrays: SparseVector, SparseMatrixCSC
-using Compat: hasfield
+using Compat: hasfield, hasproperty
 
 export frule, rrule  # core function
 # rule configurations

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -183,7 +183,7 @@ function (project::ProjectTo{AbstractArray})(dx::AbstractArray{S,M}) where {S,M}
     end
     # Then deal with the elements. One projector if AbstractArray{<:Number},
     # or one per element for arrays of anything else, including arrays of arrays:
-    dz = if hasfield(typeof(backing(project)), :element)
+    dz = if hasproperty(project, :element)
         T = project_type(project.element)
         S <: T ? dy : map(project.element, dy)
     else


### PR DESCRIPTION
In nested AD using `hasfield` makes Zygote sad.
Also it is ugly compared to `hasproperty`

I thought I caught all uses of this in #391
but one must have been missed -- it was a huge PR.