### PR TITLE
Don't try and convert to FloatX except if AbstractFloat (option 2)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -135,13 +135,44 @@ ProjectTo(::Real) = ProjectTo{Real}()
 ProjectTo(::Complex) = ProjectTo{Complex}()
 ProjectTo(::Number) = ProjectTo{Number}()
 for T in (Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64)
-    # Preserve low-precision floats as accidental promotion is a common perforance bug
+    # Preserve low-precision floats as accidental promotion is a common perforance bug    
     @eval ProjectTo(::$T) = ProjectTo{$T}()
 end
 ProjectTo(x::Integer) = ProjectTo(float(x))
 ProjectTo(x::Complex{<:Integer}) = ProjectTo(float(x))
-(::ProjectTo{T})(dx::Number) where {T<:Number} = convert(T, dx)
-(::ProjectTo{T})(dx::Number) where {T<:Real} = convert(T, real(dx))
+
+# Preserve low-precision floats as accidental promotion is a common perforance bug
+(::ProjectTo{T})(dx::AbstractFloat) where T<:AbstractFloat = convert(T, dx)
+(::ProjectTo{T})(dx::Integer) where T<:AbstractFloat = convert(T, dx)
+
+
+# We asked for a number/real and they gave use one. We did ask for a particular concrete
+# type, but that is just for the preserving low precision floats, which is handled above.
+# Any Number/Real actually occupies the same subspace, so we can trust them.
+# In particular, this makes weirder Real subtypes that are not simply the values like
+# ForwardDiff.Dual and Symbolics.Sym work, because we stay out of their way.
+(::ProjectTo{<:Number})(dx::Number) where {T<:Number} = dx
+(::ProjectTo{<:Real})(dx::Real) = dx
+
+(::ProjectTo{T})(dx::Complex) where T<:Real = ProjectTo(zero(T))(real(dx))
+
+# Complex 
+function (proj::ProjectTo{<:Complex{<:AbstractFloat}})(
+    dx::Complex{<:Union{AbstractFloat,Integer}}
+)   
+    # in this case we can just convert as we know we are dealing with 
+    # boring floating point types or integers
+    return convert(project_type(proj), dx)
+end
+# Pass though non-AbstractFloat to project each component
+function (::ProjectTo{<:Complex{T}})(dx::Complex) where T
+    project = ProjectTo(zero(T))
+    return Complex(project(real(dx)), project(imag(dx)))
+end
+function (::ProjectTo{<:Complex{T}})(dx::Real) where T
+    project = ProjectTo(zero(T))
+    return Complex(project(dx), project(zero(dx)))
+end
 
 # Arrays
 # If we don't have a more specialized `ProjectTo` rule, we just assume that there is


### PR DESCRIPTION
Alternative to https://github.com/JuliaDiff/ChainRulesCore.jl/pull/417
which also says to leave integers alone as well.
Which @DhairyaLGandhi  likes the idea of.
(I can see that it might lead to some faster code and avoid allocations)

> 
> One option to fix  the issues with tying to use ForwardDiff on a `rrule` pullback that makes use of `ProjectTo`
> See discussion on https://github.com/JuliaDiff/ForwardDiff.jl/pull/538.
> 
> Which fixes the following test that fails in https://github.com/FluxML/Zygote.jl/pull/1035/
> ```julia
>   using Zygote
>   dx, dy = diaghessian(f34, xs, y)
>   @test size(dx) == size(xs)
>   @test vec(dx) ≈ diag(hessian(x -> f34(x,y), xs))
>   @test dy ≈ hessian(y -> f34(xs,y), y)
> ```


This option basically says:
All subtypes of `Real` represent the same subspace: all of Real.
So if you give me one that is not a `AbstractFloat` subtype (.e.g `Integer` or `Dual`) I am just going to leave it alone.
But if you give me a `AbstractFloat`, I will fix the precision to match what i saw in the primal pass.