### PR TITLE
Fix a warning in CI on 1.0

### DIFF
--- a/src/projection.jl
+++ b/src/projection.jl
@@ -365,7 +365,7 @@ end
 
 # another strategy is just to use the AbstractArray method
 function ProjectTo(x::Tridiagonal{T}) where {T<:Number}
-    notparent = invoke(ProjectTo, Tuple{AbstractArray{T}} where {T<:Number}, x)
+    notparent = invoke(ProjectTo, Tuple{AbstractArray{T2}} where {T2<:Number}, x)
     return ProjectTo{Tridiagonal}(; notparent=notparent)
 end
 function (project::ProjectTo{Tridiagonal})(dx::AbstractArray)


### PR DESCRIPTION
This should silence the following:
```
WARNING: local variable T conflicts with a static parameter in Type at /home/runner/work/ChainRulesCore.jl/ChainRulesCore.jl/src/projection.jl:368.
```
No functional change, no need for a release. 