### PR TITLE
Reduce complexity of ProjectTo constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.0.2"
+version = "1.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -169,7 +169,7 @@ function scalar_frule_expr(__source__, f, call, setup_stmts, inputs, partials)
     return @strip_linenos quote
         # _ is the input derivative w.r.t. function internals. since we do not
         # allow closures/functors with @scalar_rule, it is always ignored
-        function ChainRulesCore.frule((_, $(Δs...)), ::typeof($f), $(inputs...))
+        function ChainRulesCore.frule((_, $(Δs...)), ::Core.Typeof($f), $(inputs...))
             $(__source__)
             $(esc(:Ω)) = $call
             $(setup_stmts...)
@@ -206,7 +206,7 @@ function scalar_rrule_expr(__source__, f, call, setup_stmts, inputs, partials)
     end
 
     return @strip_linenos quote
-        function ChainRulesCore.rrule(::typeof($f), $(inputs...))
+        function ChainRulesCore.rrule(::Core.Typeof($f), $(inputs...))
             $(__source__)
             $(esc(:Ω)) = $call
             $(setup_stmts...)
@@ -233,7 +233,7 @@ end
 Returns the expression for the propagation of
 the input gradient `Δs` though the partials `∂s`.
 Specify `_conj = true` to conjugate the partials.
-Projector `proj` is a function that will be applied at the end; 
+Projector `proj` is a function that will be applied at the end;
     for `rrules` it is usually a `ProjectTo(x)`, for `frules` it is `identity`
 """
 function propagation_expr(Δs, ∂s, _conj=false, proj=identity)


### PR DESCRIPTION
By avoiding a lot of the kwarg machinery when it is not needed.
Helps get some Diffractor performance back after the ProjectTo
change.

Also fix an issue where `@scalar_rule` was using `typeof` not `Typeof`
creating incorrect rules for constructors.