### PR TITLE
Fix #426 -- gradient of Ref is a Tangent

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/differentials/abstract_zero.jl
+++ b/src/differentials/abstract_zero.jl
@@ -25,6 +25,10 @@ Base.transpose(z::AbstractZero) = z
 Base.:/(z::AbstractZero, ::Any) = z
 
 Base.convert(::Type{T}, x::AbstractZero) where T <: Number = zero(T)
+(::Type{T})(xs::AbstractZero...) where T <: Number = zero(T)
+
+(::Type{Complex})(x::AbstractZero, y::Real) = Complex(false, y)
+(::Type{Complex})(x::Real, y::AbstractZero) = Complex(x, false)
 
 Base.getindex(z::AbstractZero, k) = z
 

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -248,8 +248,11 @@ function _projection_mismatch(axes_x::Tuple, size_dx::Tuple)
     )
 end
 
+#####
+##### `Base`, part II: return of the Tangent
+#####
+
 # Ref
-# This can't be its own tangent, so it standardises on a Tangent{<:Ref}
 function ProjectTo(x::Ref)
     sub = ProjectTo(x[])  # should we worry about isdefined(Ref{Vector{Int}}(), :x)? 
     if sub isa ProjectTo{<:AbstractZero}
@@ -258,7 +261,6 @@ function ProjectTo(x::Ref)
         return ProjectTo{Ref}(; type=typeof(x), x=sub)
     end
 end
-(project::ProjectTo{Ref})(dx::Ref) = Tangent{project.type}(; x=project.x(dx[]))
 (project::ProjectTo{Ref})(dx::Tangent) = Tangent{project.type}(; x=project.x(dx.x))
 # Since this works like a zero-array in broadcasting, it should also accept a number:
 (project::ProjectTo{Ref})(dx::Number) = Tangent{project.type}(; x=project.x(dx))

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -124,7 +124,7 @@ ProjectTo(::Any) # just to attach docstring
 # Zero
 ProjectTo(::AbstractZero) = ProjectTo{NoTangent}()  # Any x::Zero in forward pass makes this one projector,
 (::ProjectTo{NoTangent})(dx) = NoTangent()          # but this is the projection only for nonzero gradients,
-(::ProjectTo{NoTangent})(::NoTangent) = NoTangent() # and this one solves an ambiguity.
+(::ProjectTo{NoTangent})(dx::AbstractZero) = dx     # and this one solves an ambiguity.
 
 # Also, any explicit construction with fields, where all fields project to zero, itself
 # projects to zero. This simplifies projectors for wrapper types like Diagonal([true, false]).

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -167,9 +167,7 @@ end
 (::ProjectTo{T})(dx::Integer) where {T<:Complex{<:AbstractFloat}} = convert(T, dx)
 
 # Other numbers, including e.g. ForwardDiff.Dual and Symbolics.Sym, should pass through.
-# We assume (lacking evidence to the contrary) that it is the right subspace of numebers
-# The (::ProjectTo{T})(::T) method doesn't work because we are allowing a different
-# Number type that might not be a subtype of the `project_type`.
+# We assume (lacking evidence to the contrary) that it is the right subspace of numebers.
 (::ProjectTo{<:Number})(dx::Number) = dx
 
 (project::ProjectTo{<:Real})(dx::Complex) = project(real(dx))

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -173,6 +173,11 @@ end
 (project::ProjectTo{<:Real})(dx::Complex) = project(real(dx))
 (project::ProjectTo{<:Complex})(dx::Real) = project(complex(dx))
 
+# Tangents: we prefer to reconstruct numbers, but only safe to try when their constructor
+# understands, including a mix of Zeros & reals. Other cases, we just let through:
+(project::ProjectTo{<:Complex})(dx::Tangent{<:Number}) = project(Complex(dx.re, dx.im))
+(::ProjectTo{<:Number})(dx::Tangent{<:Number}) = dx
+
 # Arrays
 # If we don't have a more specialized `ProjectTo` rule, we just assume that there is
 # no structure worth re-imposing. Then any array is acceptable as a gradient.

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -270,6 +270,7 @@ end
 # Row vectors
 function ProjectTo(x::LinearAlgebra.AdjointAbsVec)
     sub = ProjectTo(parent(x))
+    sub isa ProjectTo{<:AbstractZero} && return sub
     return ProjectTo{Adjoint}(; parent=sub)
 end
 # Note that while [1 2; 3 4]' isa Adjoint, we use ProjectTo{Adjoint} only to encode AdjointAbsVec.
@@ -288,6 +289,7 @@ end
 
 function ProjectTo(x::LinearAlgebra.TransposeAbsVec)
     sub = ProjectTo(parent(x))
+    sub isa ProjectTo{<:AbstractZero} && return sub
     return ProjectTo{Transpose}(; parent=sub)
 end
 function (project::ProjectTo{Transpose})(dx::LinearAlgebra.AdjOrTransAbsVec)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -266,6 +266,7 @@ function ProjectTo(x::Ref)
     end
 end
 (project::ProjectTo{Ref})(dx::Tangent) = Tangent{project.type}(; x=project.x(dx.x))
+(project::ProjectTo{Ref})(dx::Ref) = Tangent{project.type}(; x=project.x(dx[]))
 # Since this works like a zero-array in broadcasting, it should also accept a number:
 (project::ProjectTo{Ref})(dx::Number) = Tangent{project.type}(; x=project.x(dx))
 

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -132,9 +132,8 @@ const _PZ = ProjectTo{<:AbstractZero}
 ProjectTo{P}(::NamedTuple{T, <:Tuple{_PZ, Vararg{<:_PZ}}}) where {P,T} = ProjectTo{NoTangent}()
 
 # Tangent
-# This may be produced from e.g. x=range(1,2,length=3). There need not be any
-# AbstractArray representation of such a tangent, so we just pass it along,
-# and trust that projection on fields before the constructor will act if necessary.
+# We haven't entirely figured out when to convert Tangents to "natural" representations such as
+# dx::AbstractArray (when both are possible), or the reverse. So for now we just pass them through:
 (::ProjectTo{T})(dx::Tangent{<:T}) where {T} = dx
 
 #####

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -115,7 +115,6 @@ ProjectTo{AbstractArray}(element = ProjectTo{Float64}(), axes = (Base.OneTo(2), 
 ProjectTo(::Any) # just to attach docstring
 
 # Generic
-(::ProjectTo{T})(dx::T) where {T} = dx  # not always correct but we have special cases for when it isn't
 (::ProjectTo{T})(dx::AbstractZero) where {T} = dx
 (::ProjectTo{T})(dx::NotImplemented) where {T} = dx
 
@@ -132,8 +131,6 @@ ProjectTo(::AbstractZero) = ProjectTo{NoTangent}()  # Any x::Zero in forward pas
 # AbstractArray representation of such a tangent, so we just pass it along,
 # and trust that projection on fields before the constructor will act if necessary.
 (::ProjectTo{T})(dx::Tangent{<:T}) where {T} = dx
-
-# (project::ProjectTo{<:AbstractArray})(dx::Tangent{<:AbstractArray}) = dx 
 
 #####
 ##### `Base`

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -265,7 +265,7 @@ function ProjectTo(x::Ref)
         return ProjectTo{Ref}(; type=typeof(x), x=sub)
     end
 end
-(project::ProjectTo{Ref})(dx::Tangent) = Tangent{project.type}(; x=project.x(dx.x))
+(project::ProjectTo{Ref})(dx::Tangent{<:Ref}) = Tangent{project.type}(; x=project.x(dx.x))
 (project::ProjectTo{Ref})(dx::Ref) = Tangent{project.type}(; x=project.x(dx[]))
 # Since this works like a zero-array in broadcasting, it should also accept a number:
 (project::ProjectTo{Ref})(dx::Number) = Tangent{project.type}(; x=project.x(dx))

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -175,7 +175,7 @@ end
 
 # Tangents: we prefer to reconstruct numbers, but only safe to try when their constructor
 # understands, including a mix of Zeros & reals. Other cases, we just let through:
-(project::ProjectTo{<:Complex})(dx::Tangent{<:Number}) = project(Complex(dx.re, dx.im))
+(project::ProjectTo{<:Complex})(dx::Tangent{<:Complex}) = project(Complex(dx.re, dx.im))
 (::ProjectTo{<:Number})(dx::Tangent{<:Number}) = dx
 
 # Arrays

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -176,13 +176,12 @@ end
 
 # For arrays of numbers, just store one projector:
 function ProjectTo(x::AbstractArray{T}) where {T<:Number}
-    element = T <: Irrational ? ProjectTo{Real}() : ProjectTo(zero(T))
-    if element isa ProjectTo{<:AbstractZero}
-        return ProjectTo{NoTangent}() # short-circuit if all elements project to zero
-    else
-        return ProjectTo{AbstractArray}(; element=element, axes=axes(x))
-    end
+    return ProjectTo{AbstractArray}(; element=_eltype_projectto(T), axes=axes(x))
 end
+ProjectTo(x::AbstractArray{Bool}) = ProjectTo{NoTangent}()
+
+_eltype_projectto(::Type{T}) where {T<:Number} = ProjectTo(zero(T))
+_eltype_projectto(::Type{<:Irrational}) = ProjectTo{Real}()
 
 # In other cases, store a projector per element:
 function ProjectTo(xs::AbstractArray)

--- a/test/differentials/abstract_zero.jl
+++ b/test/differentials/abstract_zero.jl
@@ -64,9 +64,15 @@
         @test complex(z, z) === z
         @test complex(z, 2.0) === Complex{Float64}(0.0, 2.0)
         @test complex(1.5, z) === Complex{Float64}(1.5, 0.0)
+        @test Complex(z, 2.0) === Complex{Float64}(0.0, 2.0)
+        @test Complex(1.5, z) === Complex{Float64}(1.5, 0.0)
+        @test ComplexF64(z, 2.0) === Complex{Float64}(0.0, 2.0)
+        @test ComplexF64(1.5, z) === Complex{Float64}(1.5, 0.0)
 
-        @test convert(Int64, ZeroTangent()) == 0
-        @test convert(Float64, ZeroTangent()) == 0.0
+        @test convert(Bool, ZeroTangent()) === false
+        @test convert(Int64, ZeroTangent()) === 0
+        @test convert(Float32, ZeroTangent()) === 0.0f0
+        @test convert(ComplexF64, ZeroTangent()) === 0.0 + 0.0im
     end
 
     @testset "NoTangent" begin

--- a/test/differentials/abstract_zero.jl
+++ b/test/differentials/abstract_zero.jl
@@ -70,7 +70,7 @@
         @test ComplexF64(1.5, z) === Complex{Float64}(1.5, 0.0)
 
         @test convert(Bool, ZeroTangent()) === false
-        @test convert(Int64, ZeroTangent()) === 0
+        @test convert(Int64, ZeroTangent()) === Int64(0)
         @test convert(Float32, ZeroTangent()) === 0.0f0
         @test convert(ComplexF64, ZeroTangent()) === 0.0 + 0.0im
     end

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -114,14 +114,14 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
 
     @testset "Base: Ref" begin
         pref = ProjectTo(Ref(2.0))
-        @test pref(Ref(3 + im)).x === 3.0
+        @test_skip pref(Ref(3 + im)).x === 3.0
         @test pref(4).x === 4.0  # also re-wraps scalars
-        @test pref(Ref{Any}(5.0)) isa Tangent{<:Base.RefValue}
+        @test_skip pref(Ref{Any}(5.0)) isa Tangent{<:Base.RefValue}
         pref2 = ProjectTo(Ref{Any}(6 + 7im))
-        @test pref2(Ref(8)).x === 8.0 + 0.0im
+        @test_skip pref2(Ref(8)).x === 8.0 + 0.0im
 
         prefvec = ProjectTo(Ref([1, 2, 3 + 4im]))  # recurses into contents
-        @test prefvec(Ref(1:3)).x isa Vector{ComplexF64}
+        @test_skip prefvec(Ref(1:3)).x isa Vector{ComplexF64}
         @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
 
         @test ProjectTo(Ref(true)) isa ProjectTo{NoTangent}

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -122,7 +122,7 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
 
         prefvec = ProjectTo(Ref([1, 2, 3 + 4im]))  # recurses into contents
         @test_skip prefvec(Ref(1:3)).x isa Vector{ComplexF64}
-        @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
+        @test_skip @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
 
         @test ProjectTo(Ref(true)) isa ProjectTo{NoTangent}
         @test ProjectTo(Ref([false]')) isa ProjectTo{NoTangent}

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -117,15 +117,19 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
 
     @testset "Base: Ref" begin
         pref = ProjectTo(Ref(2.0))
-        @test_skip pref(Ref(3 + im)).x === 3.0
+        @test pref(Ref(3 + im)).x === 3.0
+        @test pref(Tangent{Base.RefValue}(x = 3 + im)).x === 3.0
         @test pref(4).x === 4.0  # also re-wraps scalars
-        @test_skip pref(Ref{Any}(5.0)) isa Tangent{<:Base.RefValue}
+        @test pref(Ref{Any}(5.0)) isa Tangent{<:Base.RefValue}
+
         pref2 = ProjectTo(Ref{Any}(6 + 7im))
-        @test_skip pref2(Ref(8)).x === 8.0 + 0.0im
+        @test pref2(Ref(8)).x === 8.0 + 0.0im
+        @test pref2(Tangent{Base.RefValue}(x = 8)).x === 8.0 + 0.0im
 
         prefvec = ProjectTo(Ref([1, 2, 3 + 4im]))  # recurses into contents
-        @test_skip prefvec(Ref(1:3)).x isa Vector{ComplexF64}
-        @test_skip @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
+        @test prefvec(Ref(1:3)).x isa Vector{ComplexF64}
+        @test prefvec(Tangent{Base.RefValue}(x = 1:3)).x isa Vector{ComplexF64}
+        @test_skip @test_throws DimensionMismatch prefvec(Tangent{Base.RefValue}(x = 1:5))
 
         @test ProjectTo(Ref(true)) isa ProjectTo{NoTangent}
         @test ProjectTo(Ref([false]')) isa ProjectTo{NoTangent}

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -299,11 +299,12 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
     @testset "AbstractZero" begin
         pz = ProjectTo(ZeroTangent())
         pz(0) == NoTangent()
-        @test_broken pz(ZeroTangent()) === ZeroTangent()  # not sure how NB this is to preserve
+        @test pz(ZeroTangent()) === ZeroTangent()  # not sure how NB this is to preserve
         @test pz(NoTangent()) === NoTangent()
 
         pb = ProjectTo(true) # Bool is categorical
         @test pb(2) === NoTangent()
+        @test pb(ZeroTangent()) isa AbstractZero  # was a method ambiguity!
 
         # all projectors preserve Zero, and specific type, via one fallback method:
         @test ProjectTo(pi)(ZeroTangent()) === ZeroTangent()

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -41,11 +41,16 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
     @testset "Dual" begin # some weird Real subtype that we should basically leave alone
         @test ProjectTo(1.0)(Dual(1.0, 2.0)) isa Dual
         @test ProjectTo(1.0)(Dual(1, 2)) isa Dual
+
+        # real & complex
         @test ProjectTo(1.0 + 1im)(Dual(1.0, 2.0)) isa Complex{<:Dual}
         @test ProjectTo(1.0 + 1im)(
             Complex(Dual(1.0, 2.0), Dual(1.0, 2.0))
         ) isa Complex{<:Dual}
         @test ProjectTo(1.0)(Complex(Dual(1.0, 2.0), Dual(1.0, 2.0))) isa Dual
+
+        # Tangent
+        @test ProjectTo(Dual(1.0, 2.0))(Tangent{Dual}(; value=1.0)) isa Tangent
     end
 
     @testset "Base: arrays of numbers" begin

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -123,6 +123,9 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
         prefvec = ProjectTo(Ref([1, 2, 3 + 4im]))  # recurses into contents
         @test prefvec(Ref(1:3)).x isa Vector{ComplexF64}
         @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
+
+        @test ProjectTo(Ref(true)) isa ProjectTo{NoTangent}
+        @test_broken ProjectTo(Ref([false]')) isa ProjectTo{NoTangent}
     end
 
     #####

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -125,7 +125,7 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
         @test_throws DimensionMismatch prefvec(Ref{Any}(1:5))
 
         @test ProjectTo(Ref(true)) isa ProjectTo{NoTangent}
-        @test_broken ProjectTo(Ref([false]')) isa ProjectTo{NoTangent}
+        @test ProjectTo(Ref([false]')) isa ProjectTo{NoTangent}
     end
 
     #####
@@ -172,6 +172,9 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
 
         # issue #410
         @test padj([NoTangent() NoTangent() NoTangent()]) === NoTangent()
+
+        @test ProjectTo(adj([true, false]))([1 2]) isa AbstractZero
+        @test ProjectTo(adj([[true], [false]])) isa ProjectTo{<:AbstractZero}
     end
 
     @testset "LinearAlgebra: dense structured matrices" begin

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -33,6 +33,9 @@ Base.zero(x::Dual) = Dual(zero(x.value), zero(x.partial))
         @test ProjectTo(1.0f0 + 2im)(3) === 3.0f0 + 0im
         @test ProjectTo(big(1.0))(2) === 2
         @test ProjectTo(1.0)(2) === 2.0
+
+        # Tangents
+        ProjectTo(1.0f0 + 2im)(Tangent{ComplexF64}(re=1, im=NoTangent())) === 1.0f0 + 0.0f0im
     end
 
     @testset "Dual" begin # some weird Real subtype that we should basically leave alone


### PR DESCRIPTION
There is a bit of a mismatch between ProjectTo (which is now fairly permissive) and Tangent & friends (which want to reconstruct precisely the same type of struct). This PR makes the former more often just pass the latter along. Thus:
```julia
julia> x = 1:3.0
1.0:1.0:3.0

julia> dx = Tangent{typeof(x)}(ref=NoTangent(),step=0.1,len=NoTangent(),offset=NoTangent());

julia> ProjectTo(x)(dx)
Tangent{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}}}(ref = NoTangent(), step = 0.1, len = NoTangent(), offset = NoTangent())

julia> y = 1.0+im;

julia> dy = Tangent{typeof(y)}(; re=NoTangent(), im=0.1);

julia> ProjectTo(y)(dy)
Tangent{ComplexF64}(re = NoTangent(), im = 0.1)
```
Here `dx` is supposed to be the gradient from say `last(x)/10`. That could have been represented as `[0, 0, 0.1]`, but once it's in this Tangent form, I'm not sure there's a good way to turn it back into an AbstractVector. 

For `dy` we could of course make another complex number, probably should. Should this be for all numbers, or just Complex? Or maybe this never occurs? 

This also changes how `Ref` is handled. I'm not sure Ref can be its own gradient, e.g. it doesn't have `zero(::Ref)`. So perhaps it should always be a Tangent. 
```julia
julia> z = Ref(3);

julia> z = Ref(3)
Base.RefValue{Int64}(3)

julia> ProjectTo(z)(Ref(1.0 + im))
Tangent{Base.RefValue{Int64}}(x = 1.0,)
```
Maybe that's a bit of a change to what ProjectTo says it does, deserves some thought? Maybe including `Ref` at all was a mistake, sorry. Or maybe we want to do the same thing for Tuple, too?

Closes #426