### PR TITLE
RFC: accept Tuple Tangent for arrays?

### DIFF
--- a/src/projection.jl
+++ b/src/projection.jl
@@ -241,6 +241,12 @@ function (project::ProjectTo{AbstractArray})(dx::Number) # ... so we restore fro
     return fill(project.element(dx))
 end
 
+# Accept the Tangent corresponding to a Tuple -- Zygote's splats produce these
+function (project::ProjectTo{AbstractArray})(dx::Tangent{<:Any, <:Tuple})
+    dy = reshape(collect(backing(dx)), project.axes)
+    return project(dy)
+end
+
 # Ref -- works like a zero-array, also allows restoration from a number:
 ProjectTo(x::Ref) = ProjectTo{Ref}(; x=ProjectTo(x[]))
 (project::ProjectTo{Ref})(dx::Ref) = Ref(project.x(dx[]))


### PR DESCRIPTION
This does this:
```
julia> ProjectTo([1 2; 3 4])(Tangent{Tuple}(0.1,2,30,400))
2×2 Matrix{Float64}:
 0.1   30.0
 2.0  400.0

julia> ProjectTo([1,2,3,4]')(Tangent{Tuple}(0.1,2,30,400))
ERROR: DimensionMismatch("array with ndims(x) == 1 >  0 cannot have dx::Number")
```
as a step towards solving this:
```
julia> Zygote.gradient(x -> +(x...), [1 2; 3 4])[1]
(1, 1, 1, 1)
```
I'm not entirely sure this should be handled here not in Zygote, what thoughts?