### PR TITLE
RFC: Structural-to-Natural Bijections

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -46,6 +46,12 @@ Private = false
 ProjectTo
 ```
 
+## Structural-Natural Bijections
+```@docs
+to_natural
+to_structural
+```
+
 ## Internal
 ```@docs
 ChainRulesCore.AbstractTangent

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -15,6 +15,7 @@ export ProjectTo, canonicalize, unthunk  # differential operations
 export add!!  # gradient accumulation operations
 # differentials
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk
+export Bijections, to_natural, to_structural
 
 include("compat.jl")
 include("debug_mode.jl")
@@ -28,6 +29,7 @@ include("differentials/notimplemented.jl")
 include("differential_arithmetic.jl")
 include("accumulation.jl")
 include("projection.jl")
+include("structural_natural_bijections.jl")
 
 include("config.jl")
 include("rules.jl")

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -91,3 +91,14 @@ to_natural(b::Bijections{P}, t::Tangent) where {P<:Transpose} = Transpose(t.pare
 function to_structural(b::Bijections{P}, t::Transpose) where {P<:Transpose}
     return Tangent{P}(parent=t.parent)
 end
+
+# UpperHessenberg
+Bijections(::P) where {P<:UpperHessenberg} = Bijections{P, Nothing}(nothing)
+
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:UpperHessenberg}
+    return UpperHessenberg(t.data)
+end
+
+function to_structural(b::Bijections{P}, n::UpperHessenberg) where {P<:UpperHessenberg}
+    return Tangent{P}(data=n.data)
+end

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -64,3 +64,19 @@ to_natural(b::Bijections{P}, t::Tangent) where {P<:Hermitian} = Hermitian(t.data
 function to_structural(b::Bijections{P}, n::Hermitian) where {P<:Hermitian}
     return Tangent{P}(data=n.data)
 end
+
+# Adjoint
+Bijections(::P) where {P<:Adjoint} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{P}, t::Tangent) where {P<:Adjoint} = Adjoint(t.parent)
+
+to_structural(b::Bijections{P}, t::Adjoint) where {P<:Adjoint} = Tangent{P}(parent=t.parent)
+
+# Transpose
+Bijections(::P) where {P<:Transpose} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{P}, t::Tangent) where {P<:Transpose} = Transpose(t.parent)
+
+function to_structural(b::Bijections{P}, t::Transpose) where {P<:Transpose}
+    return Tangent{P}(parent=t.parent)
+end

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -1,0 +1,62 @@
+struct Bijections{P, D}
+    info::D
+end
+
+"""
+    to_natural(b::Bijections, t::Tangent)
+
+Map from a structural `Tangent` to a natural tangent. This transformation shouln't change
+the tangent, just its representation.
+"""
+to_natural(b::Bijections, t::Tangent)
+
+"""
+    to_structural(b::Bijections, n)
+
+Map from an natural tangent `n` to a `Tangent`. This transformation shouldn't change the
+tangent, just its representation.
+"""
+to_structural(b::Bijections, n)
+
+# Diagonal
+Bijections(::P) where {P<:Diagonal} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{<:Diagonal}, t::Tangent) = Diagonal(t.diag)
+
+to_structural(b::Bijections{P}, n::Diagonal) where {P<:Diagonal} = Tangent{P}(diag=n.diag)
+
+# UpperTriangular
+Bijections(::P) where {P<:UpperTriangular} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{<:UpperTriangular}, t::Tangent) = UpperTriangular(t.data)
+
+function to_structural(b::Bijections{P}, n::UpperTriangular) where {P<:UpperTriangular}
+    return Tangent{P}(data=n.data)
+end
+
+# LowerTriangular
+Bijections(::P) where {P<:LowerTriangular} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{<:LowerTriangular}, t::Tangent) = LowerTriangular(t.data)
+
+function to_structural(b::Bijections{P}, n::LowerTriangular) where {P<:LowerTriangular}
+    return Tangent{P}(data=n.data)
+end
+
+# Symmetric
+Bijections(::P) where {P<:Symmetric} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{<:Symmetric}, t::Tangent) = Symmetric(t.data)
+
+function to_structural(b::Bijections{P}, n::Symmetric) where {P<:Symmetric}
+    return Tangent{P}(data=n.data)
+end
+
+# Hermitian
+Bijections(::P) where {P<:Hermitian} = Bijections{P, Nothing}(nothing)
+
+to_natural(b::Bijections{<:Hermitian}, t::Tangent) = Hermitian(t.data)
+
+function to_structural(b::Bijections{P}, n::Hermitian) where {P<:Hermitian}
+    return Tangent{P}(data=n.data)
+end

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -107,15 +107,17 @@ function to_structural(b::Bijections{P}, n::SymTridiagonal) where {P<:SymTridiag
     return Tangent{P}(dv=n.dv, ev=n.ev)
 end
 
-# UpperHessenberg
-Bijections(::P) where {P<:UpperHessenberg} = Bijections{P, Nothing}(nothing)
+if VERSION >= v"1.3"
+    # UpperHessenberg
+    Bijections(::P) where {P<:UpperHessenberg} = Bijections{P, Nothing}(nothing)
 
-function to_natural(b::Bijections{P}, t::Tangent) where {P<:UpperHessenberg}
-    return UpperHessenberg(t.data)
-end
+    function to_natural(b::Bijections{P}, t::Tangent) where {P<:UpperHessenberg}
+        return UpperHessenberg(t.data)
+    end
 
-function to_structural(b::Bijections{P}, n::UpperHessenberg) where {P<:UpperHessenberg}
-    return Tangent{P}(data=n.data)
+    function to_structural(b::Bijections{P}, n::UpperHessenberg) where {P<:UpperHessenberg}
+        return Tangent{P}(data=n.data)
+    end
 end
 
 # UniformScaling

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -18,6 +18,17 @@ tangent, just its representation.
 """
 to_structural(b::Bijections, n)
 
+# Bidiagonal
+Bijections(p::P) where {P<:Bidiagonal} = Bijections{P, Char}(p.uplo)
+
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:Bidiagonal}
+    return Bidiagonal(t.dv, t.ev, b.info)
+end
+
+function to_structural(b::Bijections{P}, n::Bidiagonal) where {P<:Bidiagonal}
+    return Tangent{P}(dv=n.dv, ev=n.ev)
+end
+
 # Diagonal
 Bijections(::P) where {P<:Diagonal} = Bijections{P, Nothing}(nothing)
 

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -59,18 +59,22 @@ function to_structural(b::Bijections{P}, n::LowerTriangular) where {P<:LowerTria
 end
 
 # Symmetric
-Bijections(::P) where {P<:Symmetric} = Bijections{P, Nothing}(nothing)
+Bijections(p::P) where {P<:Symmetric} = Bijections{P, Char}(p.uplo)
 
-to_natural(b::Bijections{P}, t::Tangent) where {P<:Symmetric} = Symmetric(t.data)
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:Symmetric}
+    return Symmetric(t.data, Symbol(b.info))
+end
 
 function to_structural(b::Bijections{P}, n::Symmetric) where {P<:Symmetric}
     return Tangent{P}(data=n.data)
 end
 
 # Hermitian
-Bijections(::P) where {P<:Hermitian} = Bijections{P, Nothing}(nothing)
+Bijections(p::P) where {P<:Hermitian} = Bijections{P, Char}(p.uplo)
 
-to_natural(b::Bijections{P}, t::Tangent) where {P<:Hermitian} = Hermitian(t.data)
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:Hermitian}
+    return Hermitian(t.data, Symbol(b.info))
+end
 
 function to_structural(b::Bijections{P}, n::Hermitian) where {P<:Hermitian}
     return Tangent{P}(data=n.data)

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -92,6 +92,17 @@ function to_structural(b::Bijections{P}, t::Transpose) where {P<:Transpose}
     return Tangent{P}(parent=t.parent)
 end
 
+# SymTridiagonal
+Bijections(::P) where {P<:SymTridiagonal} = Bijections{P, Nothing}(nothing)
+
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:SymTridiagonal}
+    return SymTridiagonal(t.dv, t.ev)
+end
+
+function to_structural(b::Bijections{P}, n::SymTridiagonal) where {P<:SymTridiagonal}
+    return Tangent{P}(dv=n.dv, ev=n.ev)
+end
+
 # UpperHessenberg
 Bijections(::P) where {P<:UpperHessenberg} = Bijections{P, Nothing}(nothing)
 

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -113,3 +113,14 @@ end
 function to_structural(b::Bijections{P}, n::UpperHessenberg) where {P<:UpperHessenberg}
     return Tangent{P}(data=n.data)
 end
+
+# UniformScaling
+Bijections(::P) where {P<:UniformScaling} = Bijections{P, Nothing}(nothing)
+
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:UniformScaling}
+    return UniformScaling(t.λ)
+end
+
+function to_structural(b::Bijections{P}, n::UniformScaling) where {P<:UniformScaling}
+    return Tangent{P}(λ=n.λ)
+end

--- a/src/structural_natural_bijections.jl
+++ b/src/structural_natural_bijections.jl
@@ -21,14 +21,16 @@ to_structural(b::Bijections, n)
 # Diagonal
 Bijections(::P) where {P<:Diagonal} = Bijections{P, Nothing}(nothing)
 
-to_natural(b::Bijections{<:Diagonal}, t::Tangent) = Diagonal(t.diag)
+to_natural(b::Bijections{P}, t::Tangent) where {P<:Diagonal} = Diagonal(t.diag)
 
 to_structural(b::Bijections{P}, n::Diagonal) where {P<:Diagonal} = Tangent{P}(diag=n.diag)
 
 # UpperTriangular
 Bijections(::P) where {P<:UpperTriangular} = Bijections{P, Nothing}(nothing)
 
-to_natural(b::Bijections{<:UpperTriangular}, t::Tangent) = UpperTriangular(t.data)
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:UpperTriangular}
+    return UpperTriangular(t.data)
+end
 
 function to_structural(b::Bijections{P}, n::UpperTriangular) where {P<:UpperTriangular}
     return Tangent{P}(data=n.data)
@@ -37,7 +39,9 @@ end
 # LowerTriangular
 Bijections(::P) where {P<:LowerTriangular} = Bijections{P, Nothing}(nothing)
 
-to_natural(b::Bijections{<:LowerTriangular}, t::Tangent) = LowerTriangular(t.data)
+function to_natural(b::Bijections{P}, t::Tangent) where {P<:LowerTriangular}
+    return LowerTriangular(t.data)
+end
 
 function to_structural(b::Bijections{P}, n::LowerTriangular) where {P<:LowerTriangular}
     return Tangent{P}(data=n.data)
@@ -46,7 +50,7 @@ end
 # Symmetric
 Bijections(::P) where {P<:Symmetric} = Bijections{P, Nothing}(nothing)
 
-to_natural(b::Bijections{<:Symmetric}, t::Tangent) = Symmetric(t.data)
+to_natural(b::Bijections{P}, t::Tangent) where {P<:Symmetric} = Symmetric(t.data)
 
 function to_structural(b::Bijections{P}, n::Symmetric) where {P<:Symmetric}
     return Tangent{P}(data=n.data)
@@ -55,7 +59,7 @@ end
 # Hermitian
 Bijections(::P) where {P<:Hermitian} = Bijections{P, Nothing}(nothing)
 
-to_natural(b::Bijections{<:Hermitian}, t::Tangent) = Hermitian(t.data)
+to_natural(b::Bijections{P}, t::Tangent) where {P<:Hermitian} = Hermitian(t.data)
 
 function to_structural(b::Bijections{P}, n::Hermitian) where {P<:Hermitian}
     return Tangent{P}(data=n.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ using Test
 
     include("accumulation.jl")
     include("projection.jl")
+    include("structural_natural_bijections.jl")
 
     include("rules.jl")
     include("rule_definition_tools.jl")

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -1,8 +1,5 @@
 using ChainRulesCore: backing
 
-# Need to be able to compare `Tangent`s to verify correctness of definition of natural.
-Base.:(==)(t::Tangent, s::Tangent) = (backing(t) == backing(s))
-
 # This function specifies what we require of a natural tangent. Works for flat spaces.
 function check_bijections(primal, structural::Tangent)
     b = Bijections(primal)
@@ -18,7 +15,7 @@ function check_bijections(primal, structural::Tangent)
     @test primal + structural == primal + to_natural(b, structural)
 
     # Check that to_structural inverts to_natural.
-    @test to_structural(b, to_natural(b, structural)) == structural
+    @test to_natural(b, to_structural(b, natural)) == natural
 end
 
 struct ScaledVector <: AbstractVector{Float64}

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -54,6 +54,9 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     X = randn(5, 5)
     dX = randn(5, 5)
 
+    check_bijections(
+        Bidiagonal(x, x[1:end-1], 'U'), Tangent{Bidiagonal}(dv=dx, ev=dx[1:end-1]),
+    )
     check_bijections(Diagonal(x), Tangent{Diagonal}(diag=dx))
     check_bijections(UpperTriangular(X), Tangent{UpperTriangular}(data=dX))
     check_bijections(LowerTriangular(X), Tangent{LowerTriangular}(data=dX))

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -59,6 +59,8 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(LowerTriangular(X), Tangent{LowerTriangular}(data=dX))
     check_bijections(Symmetric(X), Tangent{Symmetric}(data=dX))
     check_bijections(Hermitian(X), Tangent{Hermitian}(data=dX))
+    check_bijections(Adjoint(X), Tangent{Adjoint}(parent=dX))
+    check_bijections(Transpose(X), Tangent{Transpose}(parent=dX))
 
     # These tests don't work. I haven't managed to figure out a natural tangent which
     # satisfies all of my tests for this ScaledVector type.

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -57,6 +57,9 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(
         Bidiagonal(x, x[1:end-1], 'U'), Tangent{Bidiagonal}(dv=dx, ev=dx[1:end-1]),
     )
+    check_bijections(
+        Bidiagonal(x, x[1:end-1], 'L'), Tangent{Bidiagonal}(dv=dx, ev=dx[1:end-1]),
+    )
     check_bijections(Diagonal(x), Tangent{Diagonal}(diag=dx))
     check_bijections(UpperTriangular(X), Tangent{UpperTriangular}(data=dX))
     check_bijections(LowerTriangular(X), Tangent{LowerTriangular}(data=dX))

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -1,0 +1,66 @@
+using ChainRulesCore: backing
+
+# Need to be able to compare `Tangent`s to verify correctness of definition of natural.
+Base.:(==)(t::Tangent, s::Tangent) = (backing(t) == backing(s))
+
+# This function specifies what we require of a natural tangent. Works for flat spaces.
+function check_bijections(primal, structural::Tangent)
+    b = Bijections(primal)
+    
+    # Check that adding tangents is the same in structural or natural.
+    sum_1 = 0.8 * structural + 0.3 * structural
+    natural = to_natural(b, structural)
+    sum_2 = to_structural(b, 0.8 * natural + 0.3 * natural)
+    @test sum_1 == sum_2
+
+    # Check that adding the structural tangent to the primal has the same effect as adding
+    # the natural.
+    @test primal + structural == primal + to_natural(b, structural)
+
+    # Check that to_structural inverts to_natural.
+    @test to_structural(b, to_natural(b, structural)) == structural
+end
+
+struct ScaledVector <: AbstractVector{Float64}
+    v::Vector{Float64}
+    α::Float64
+end
+
+Base.getindex(x::ScaledVector, n::Int) = x.α * x.v[n]
+
+Base.size(x::ScaledVector) = size(x.v)
+
+ChainRulesCore.Bijections(p::P) where {P<:ScaledVector} = Bijections{P, Float64}(p.α)
+
+function ChainRulesCore.to_natural(b::Bijections{<:ScaledVector}, t::Tangent)
+    return ScaledVector(t.v, t.α)
+end
+
+function ChainRulesCore.to_structural(
+    b::Bijections{P}, n::ScaledVector,
+) where {P<:ScaledVector}
+    return Tangent{P}(v=n.v, α=n.α)
+end
+
+# Type-piracy.
+LinearAlgebra.Symmetric(X::AbstractMatrix, uplo::Char) = Symmetric(X, Symbol(uplo))
+LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(uplo))
+
+# Bijections
+
+@testset "structural_natural_bijections" begin
+    x = randn(5)
+    dx = randn(5)
+    X = randn(5, 5)
+    dX = randn(5, 5)
+
+    check_bijections(Diagonal(x), Tangent{Diagonal}(diag=dx))
+    check_bijections(UpperTriangular(X), Tangent{UpperTriangular}(data=dX))
+    check_bijections(LowerTriangular(X), Tangent{LowerTriangular}(data=dX))
+    check_bijections(Symmetric(X), Tangent{Symmetric}(data=dX))
+    check_bijections(Hermitian(X), Tangent{Hermitian}(data=dX))
+
+    # These tests don't work. I haven't managed to figure out a natural tangent which
+    # satisfies all of my tests for this ScaledVector type.
+    # check_bijections(ScaledVector(x, 0.5), Tangent{ScaledVector}(v=dx, α=randn()))
+end

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -61,7 +61,9 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(UpperTriangular(X), Tangent{UpperTriangular}(data=dX))
     check_bijections(LowerTriangular(X), Tangent{LowerTriangular}(data=dX))
     check_bijections(Symmetric(X), Tangent{Symmetric}(data=dX))
+    check_bijections(Symmetric(X, :L), Tangent{Symmetric}(data=dX))
     check_bijections(Hermitian(X), Tangent{Hermitian}(data=dX))
+    check_bijections(Hermitian(X, :L), Tangent{Hermitian}(data=dX))
     check_bijections(Adjoint(X), Tangent{Adjoint}(parent=dX))
     check_bijections(Transpose(X), Tangent{Transpose}(parent=dX))
     check_bijections(

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -68,6 +68,7 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
         SymTridiagonal(dx, dx[1:end-1]), Tangent{SymTridiagonal}(dv=dx, ev=dx[1:end-1]),
     )
     check_bijections(UpperHessenberg(X), Tangent{UpperHessenberg}(data=dX))
+    check_bijections(UniformScaling(randn()), Tangent{UniformScaling}(λ=randn()))
 
     # These tests don't work. I haven't managed to figure out a natural tangent which
     # satisfies all of my tests for this ScaledVector type.

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -8,9 +8,9 @@ function check_bijections(primal, structural::Tangent)
     b = Bijections(primal)
     
     # Check that adding tangents is the same in structural or natural.
-    sum_1 = 0.8 * structural + 0.3 * structural
+    sum_1 = to_natural(b, 0.8 * structural + 0.3 * structural)
     natural = to_natural(b, structural)
-    sum_2 = to_structural(b, 0.8 * natural + 0.3 * natural)
+    sum_2 = 0.8 * natural + 0.3 * natural
     @test sum_1 == sum_2
 
     # Check that adding the structural tangent to the primal has the same effect as adding

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -64,6 +64,9 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(Hermitian(X), Tangent{Hermitian}(data=dX))
     check_bijections(Adjoint(X), Tangent{Adjoint}(parent=dX))
     check_bijections(Transpose(X), Tangent{Transpose}(parent=dX))
+    check_bijections(
+        SymTridiagonal(dx, dx[1:end-1]), Tangent{SymTridiagonal}(dv=dx, ev=dx[1:end-1]),
+    )
     check_bijections(UpperHessenberg(X), Tangent{UpperHessenberg}(data=dX))
 
     # These tests don't work. I haven't managed to figure out a natural tangent which

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -72,7 +72,10 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(
         SymTridiagonal(dx, dx[1:end-1]), Tangent{SymTridiagonal}(dv=dx, ev=dx[1:end-1]),
     )
-    check_bijections(UpperHessenberg(X), Tangent{UpperHessenberg}(data=dX))
+
+    if VERSION >= v"1.3"
+        check_bijections(UpperHessenberg(X), Tangent{UpperHessenberg}(data=dX))
+    end
     check_bijections(UniformScaling(randn()), Tangent{UniformScaling}(λ=randn()))
 
     # These tests don't work. I haven't managed to figure out a natural tangent which

--- a/test/structural_natural_bijections.jl
+++ b/test/structural_natural_bijections.jl
@@ -64,6 +64,7 @@ LinearAlgebra.Hermitian(X::AbstractMatrix, uplo::Char) = Hermitian(X, Symbol(upl
     check_bijections(Hermitian(X), Tangent{Hermitian}(data=dX))
     check_bijections(Adjoint(X), Tangent{Adjoint}(parent=dX))
     check_bijections(Transpose(X), Tangent{Transpose}(parent=dX))
+    check_bijections(UpperHessenberg(X), Tangent{UpperHessenberg}(data=dX))
 
     # These tests don't work. I haven't managed to figure out a natural tangent which
     # satisfies all of my tests for this ScaledVector type.


### PR DESCRIPTION
Following on from #441 , I've taken a stab at implementing bijections which map from structurals to naturals and back.
Note that this is non-breaking.

Can confirm that if you modify [this](https://github.com/JuliaDiff/ChainRules.jl/blob/87458d06f7219abf186e70be03158941e47d95e6/src/rulesets/Base/arraymath.jl#L84) `rrule` for `::Number * AbstractMatrix` to be
```julia
function rrule(
   ::typeof(*), A::CommutativeMulNumber, B::AbstractArray{<:CommutativeMulNumber}
)
    Y = A * B
    b = Bijections(Y)
    project_A = ProjectTo(A)
    project_B = ProjectTo(B)
    function times_pullback(ȳ)
        Ȳ = to_natural(b, unthunk(ȳ))
        return (
            NoTangent(),
            @thunk(project_A(dot(Ȳ, B)')),
            InplaceableThunk(
                X̄ -> mul!(X̄, conj(A), Ȳ, true, true),
                @thunk(to_structural(b, project_B(A' * Ȳ))),
            )
        )
    end
    return Y, times_pullback
end
```
which utilises the code in this PR, then the following works, and always gives structural tangents outside of the rules:
```julia
using LinearAlgebra
using Zygote

foo(x) = 5x
bar = parent

b, pullback_foo = Zygote.pullback(foo, Symmetric(randn(5, 5)))
c, pullback_bar = Zygote.pullback(bar, b)

Dc = randn(5, 5)
Db = pullback_bar(Dc)[1]
Db isa NamedTuple # structural tangent
pullback_foo(Db) # breaks on master, works with this PR
```

Probably it could do a better job of handling thunks etc (bijections should probably take care of unthunking), but that can be dealt with later.

A central part of this PR is to establish what we even expect from the natural-structural bijection.
 I've encoded this in the `check_bijections` function in the tests.
All of the tests in `check_bijections` seem to me like reasonable things that naturals / structurals ought to satisfy, but I'm not going to pretend to know if they're actually the right things. Would be interested to know what others think. Are there other properties that they ought to satisfy? Should some of the requirements be dropped?

There are a couple of things which surprised me. In particular, if you want to be able to add a structural to a primal and get the same result as adding the natural to the primal, you're forced to make the natural for a `Symmetric` just copy the data from the structural, without re-scaling or anything. I didn't expect this.

I've also found it incredibly hard to produce a natural for the `ScaledVector` type below. I had anticipated this being a simple task, then it turned out not to be -- I think this is interesting in its own right.

edit:

I've also tried out removing [this constructor rrule for Symmetric](https://github.com/JuliaDiff/ChainRules.jl/blob/ea8a5a6842d8b04b0475c30fe60fc31aa31d5db7/src/rulesets/LinearAlgebra/symmetric.jl#L9), and the corresponding one [in Zygote](https://github.com/FluxML/Zygote.jl/blob/7f2b16987dc4eab236aabd889444cabdcc6f9caf/src/lib/array.jl#L507), and found that Zygote can differentiate through `X -> parent(5 * Symmetric(X))`, as expected.

edit2: another surprising result: it seems the relationship between the natural and structural tangent for `Adjoint` and `Transpose` doesn't involve appling `adjoint` or `transpose` to the `parent` field. Perhaps I'm just getting confused by projection vs natural-structural translation though, and this is actually what we should expect?

edit3: Bidiagonal is the first type that I've come across where the `info` field is something other than `nothing`.

edit4: I think I've now covered all AbstractArrays in LinearAlgebra. Also covered UniformScaling. So far, all of the conversions have been essentially zero-cost, which is not what I expected.

edit5: missed all of the uplo stuff for Symmetric and Hermitian etc (now added).