### PR TITLE
Make `ProjectTo` convert `Tangent` back to `Diagonal`, etc, when safe

### DIFF
--- a/src/projection.jl
+++ b/src/projection.jl
@@ -495,10 +495,10 @@ end
 # Subspaces which aren't subtypes, like Diagonal inside Symmetric above:
 (project::ProjectTo{UpperTriangular})(dx::Diagonal) = project.data(dx)
 (project::ProjectTo{LowerTriangular})(dx::Diagonal) = project.data(dx)
-
-(project::ProjectTo{UpperHessenberg})(dx::Diagonal) = project.data(dx)
-(project::ProjectTo{UpperHessenberg})(dx::UpperTriangular) = project.data(dx)
-
+if VERSION >= v"1.4"
+    (project::ProjectTo{UpperHessenberg})(dx::Diagonal) = project.data(dx)
+    (project::ProjectTo{UpperHessenberg})(dx::UpperTriangular) = project.data(dx)
+end
 (project::ProjectTo{UnitUpperTriangular})(dx::Diagonal) = NoTangent()
 (project::ProjectTo{UnitLowerTriangular})(dx::Diagonal) = NoTangent()
 

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -472,7 +472,6 @@ end
 
 # Triangular
 for UL in (:UpperTriangular, :LowerTriangular, :UpperHessenberg)
-    VERSION < v"1.4" && UL == :UpperHessenberg && continue  # not defined in 1.0
     @eval begin
         ProjectTo(x::$UL) = ProjectTo{$UL}(; data=ProjectTo(parent(x)))
         (project::ProjectTo{$UL})(dx::AbstractArray) = $UL(project.data(dx))
@@ -499,10 +498,10 @@ end
 # Subspaces which aren't subtypes, like Diagonal inside Symmetric above:
 (project::ProjectTo{UpperTriangular})(dx::Diagonal) = project.data(dx)
 (project::ProjectTo{LowerTriangular})(dx::Diagonal) = project.data(dx)
-if VERSION >= v"1.4"
-    (project::ProjectTo{UpperHessenberg})(dx::Diagonal) = project.data(dx)
-    (project::ProjectTo{UpperHessenberg})(dx::UpperTriangular) = project.data(dx)
-end
+
+(project::ProjectTo{UpperHessenberg})(dx::Diagonal) = project.data(dx)
+(project::ProjectTo{UpperHessenberg})(dx::UpperTriangular) = project.data(dx)
+
 (project::ProjectTo{UnitUpperTriangular})(dx::Diagonal) = NoTangent()
 (project::ProjectTo{UnitLowerTriangular})(dx::Diagonal) = NoTangent()
 

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -436,6 +436,10 @@ end
 ProjectTo(x::Diagonal) = ProjectTo{Diagonal}(; diag=ProjectTo(x.diag))
 (project::ProjectTo{Diagonal})(dx::AbstractMatrix) = Diagonal(project.diag(diag(dx)))
 (project::ProjectTo{Diagonal})(dx::Diagonal) = Diagonal(project.diag(dx.diag))
+function (project::ProjectTo{Diagonal})(dx::AbstractArray)
+    ind = diagind(size(dx,1), size(dx,2), 0)
+    return Diagonal(project.diag(dx[ind]))
+end
 function (project::ProjectTo{Diagonal})(dx::Tangent{<:Diagonal}) # structural => natural
     return dx.diag isa ArrayOrZero ? Diagonal(project.diag(dx.diag)) : dx
 end

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -531,7 +531,7 @@ end
 (project::ProjectTo{Tridiagonal})(dx::Tridiagonal) = project.full(dx)
 (project::ProjectTo{SymTridiagonal})(dx::SymTridiagonal) = project.full(dx)
 # AbstractArray
-(proj::ProjectTo{Bidiagonal})(dx::AbstractArray) = Bidiagonal(project.full(dx), proj.uplo)
+(project::ProjectTo{Bidiagonal})(dx::AbstractArray) = Bidiagonal(project.full(dx), project.uplo)
 (project::ProjectTo{Tridiagonal})(dx::AbstractArray) = Tridiagonal(project.full(dx))
 (project::ProjectTo{SymTridiagonal})(dx::Symmetric) = SymTridiagonal(project.full(dx))
 function (project::ProjectTo{SymTridiagonal})(dx::AbstractArray)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -140,7 +140,7 @@ end
 # Tangent
 # We haven't entirely figured out when to convert Tangents to "natural" representations such as
 # dx::AbstractArray (when both are possible), or the reverse. So for now we just pass them through:
-(::ProjectTo{T})(dx::Tangent{<:T}) where {T} = dx
+(::ProjectTo)(dx::Tangent) = dx
 
 #####
 ##### `Base`

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -462,31 +462,17 @@ for (SymHerm, chk, fun) in
         end
         # This is an example of a subspace which is not a subtype,
         # not clear how broadly it's worthwhile to try to support this.
-        function (project::ProjectTo{$SymHerm})(dx::Diagonal)
-            sub = project.data # this is going to be unhappy about the size
-            sub_one = ProjectTo{project_type(sub)}(;
-                element=sub.element, axes=(sub.axes[1],)
-            )
-            return Diagonal(sub_one(dx.diag))
-        end
+        (project::ProjectTo{$SymHerm})(dx::Diagonal) =  project.data(dx)
     end
 end
 
 # Triangular
-for UL in (:UpperTriangular, :LowerTriangular, :UnitUpperTriangular, :UnitLowerTriangular) # UpperHessenberg
+for UL in (:UpperTriangular, :LowerTriangular, :UpperHessenberg)
     @eval begin
         ProjectTo(x::$UL) = ProjectTo{$UL}(; data=ProjectTo(parent(x)))
         (project::ProjectTo{$UL})(dx::AbstractArray) = $UL(project.data(dx))
         function (project::ProjectTo{$UL})(dx::Tangent{<:$UL})  # structural => natural
-            return dx.data isa ArrayOrZero ? $UL(project.data(dx.data), project.uplo) : dx
-        end
-        # Another subspace which is not a subtype, like Diagonal inside Symmetric above, equally unsure
-        function (project::ProjectTo{$UL})(dx::Diagonal)
-            sub = project.data
-            sub_one = ProjectTo{project_type(sub)}(;
-                element=sub.element, axes=(sub.axes[1],)
-            )
-            return Diagonal(sub_one(dx.diag))
+            return dx.data isa ArrayOrZero ? $UL(project.data(dx.data)) : dx
         end
     end
 end

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -84,7 +84,7 @@ function _promote_vectors(x::AbstractVector, y::AbstractVector)
     if isconcretetype(T)
         return convert(T, x), convert(T, y)
     else
-        short = map(first∘promote, x, y)
+        short = map(first ∘ promote, x, y)
         return convert(typeof(short), x), convert(typeof(short), y)
     end
 end

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -46,6 +46,9 @@ end
 for T in (:Symmetric, :Hermitian)
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero, uplo=:U) = z
 end
+LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractZero, uplo::Symbol) = NoTangent()
+LinearAlgebra.Bidiagonal(dv::AbstractArray, ev::AbstractZero, uplo::Symbol) = Bidiagonal(dv, zero(dv)[1:end-1], uplo)
+LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractArray, uplo::Symbol) = Bidiagonal(vcat(zero(ev), false), ev, uplo)
 
 """
     ZeroTangent() <: AbstractZero

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -19,9 +19,6 @@ Base.iterate(::AbstractZero, ::Any) = nothing
 Base.Broadcast.broadcastable(x::AbstractZero) = Ref(x)
 Base.Broadcast.broadcasted(::Type{T}) where {T<:AbstractZero} = T()
 
-# Linear operators
-Base.adjoint(z::AbstractZero) = z
-Base.transpose(z::AbstractZero) = z
 Base.:/(z::AbstractZero, ::Any) = z
 
 Base.convert(::Type{T}, x::AbstractZero) where {T<:Number} = zero(T)
@@ -37,7 +34,16 @@ Base.sum(z::AbstractZero; dims=:) = z
 Base.reshape(z::AbstractZero, size...) = z
 Base.reverse(z::AbstractZero, args...; kwargs...) = z
 
-(::Type{<:UniformScaling})(z::AbstractZero) = z
+# LinearAlgebra
+LinearAlgebra.adjoint(z::AbstractZero, ind...) = z
+LinearAlgebra.transpose(z::AbstractZero, ind...) = z
+
+for T in (:UniformScaling, :Adjoint, :Transpose, :Diagonal)
+    @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero) = z
+end
+for T in (:Symmetric, :Hermitian)
+    @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero, uplo=:U) = z
+end
 
 """
     ZeroTangent() <: AbstractZero

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -51,7 +51,7 @@ LinearAlgebra.Hermitian(z::AbstractZero, uplo=:U) = z
 LinearAlgebra.Bidiagonal(dv::AbstractVector, ev::AbstractZero, uplo::Symbol) = Diagonal(dv)
 function LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractVector, uplo::Symbol)
     dv = fill!(similar(ev, length(ev) + 1), 0) # can't avoid making a dummy array
-    Bidiagonal(dv, convert(typeof(dv), ev), uplo)
+    return Bidiagonal(dv, convert(typeof(dv), ev), uplo)
 end
 LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractZero, uplo::Symbol) = NoTangent()
 
@@ -60,7 +60,7 @@ LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractVector, du::AbstractVecto
 LinearAlgebra.Tridiagonal(dl::AbstractVector, d::AbstractVector, du::AbstractZero) = Bidiagonal(_promote_vectors(d, dl)..., :L)
 function LinearAlgebra.Tridiagonal(dl::AbstractVector, d::AbstractZero, du::AbstractVector)
     d = fill!(similar(dl, length(dl) + 1), 0)
-    Tridiagonal(convert(typeof(d), dl), d, convert(typeof(d), du))
+    return Tridiagonal(convert(typeof(d), dl), d, convert(typeof(d), du))
 end
 # two Zeros:
 LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractVector, du::AbstractZero) = Diagonal(d)
@@ -72,7 +72,7 @@ LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractZero, du::AbstractZero) =
 LinearAlgebra.SymTridiagonal(dv::AbstractVector, ev::AbstractZero) = Diagonal(dv)
 function LinearAlgebra.SymTridiagonal(dv::AbstractZero, ev::AbstractVector)
     dv = fill!(similar(ev, length(ev) + 1), 0)
-    SymTridiagonal(dv, convert(typeof(dv), ev))
+    return SymTridiagonal(dv, convert(typeof(dv), ev))
 end
 LinearAlgebra.SymTridiagonal(dv::AbstractZero, ev::AbstractZero) = NoTangent()
 

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -38,12 +38,12 @@ LinearAlgebra.adjoint(z::AbstractZero, ind...) = z
 LinearAlgebra.transpose(z::AbstractZero, ind...) = z
 
 for T in (
-        :UniformScaling, :Adjoint, :Transpose, :Diagonal
+        :UniformScaling, :Adjoint, :Transpose, :Diagonal,
         :UpperTriangular, :LowerTriangular, :UpperHessenberg,
         :UnitUpperTriangular, :UnitLowerTriangular,
     )
-    VERSION < v"1.4" && f == :UpperHessenberg && continue  # not defined in 1.0
-    @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero) = z
+    VERSION < v"1.4" && T == :UpperHessenberg && continue  # not defined in 1.0
+    @eval LinearAlgebra.$T(z::AbstractZero) = z
 end
 
 LinearAlgebra.Symmetric(z::AbstractZero, uplo=:U) = z

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -84,7 +84,11 @@ function _promote_vectors(x::AbstractVector, y::AbstractVector)
     if isconcretetype(T)
         return convert(T, x), convert(T, y)
     else
-        short = map(Base.splat(first ∘ promote), zip(x, y))
+        if VERSION > v"1.4"
+            short = map(first ∘ promote, x, y)
+        else  # on 1.0 and friends, neither map nor zip stop early. So we improvise
+            short = [promote(x[i], y[i])[1] for i in intersect(axes(x, 1), axes(y, 1))]
+        end
         return convert(typeof(short), x), convert(typeof(short), y)
     end
 end

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -37,7 +37,10 @@ Base.reverse(z::AbstractZero, args...; kwargs...) = z
 LinearAlgebra.adjoint(z::AbstractZero, ind...) = z
 LinearAlgebra.transpose(z::AbstractZero, ind...) = z
 
-for T in (:UniformScaling, :Adjoint, :Transpose, :Diagonal)
+for T in (
+        :UniformScaling, :Adjoint, :Transpose, :Diagonal
+        :UpperTriangular, :LowerTriangular, :UnitUpperTriangular, :UnitLowerTriangular,
+    )
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero) = z
 end
 for T in (:Symmetric, :Hermitian)

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -84,7 +84,7 @@ function _promote_vectors(x::AbstractVector, y::AbstractVector)
     if isconcretetype(T)
         return convert(T, x), convert(T, y)
     else
-        short = map(first ∘ promote, x, y)
+        short = map(Base.splat(first ∘ promote), zip(x, y))
         return convert(typeof(short), x), convert(typeof(short), y)
     end
 end

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -27,8 +27,7 @@ Base.convert(::Type{T}, x::AbstractZero) where {T<:Number} = zero(T)
 (::Type{Complex})(x::AbstractZero, y::Real) = Complex(false, y)
 (::Type{Complex})(x::Real, y::AbstractZero) = Complex(x, false)
 
-Base.getindex(z::AbstractZero, args...) = z
-
+Base.getindex(z::AbstractZero, ind...) = z
 Base.view(z::AbstractZero, ind...) = z
 Base.sum(z::AbstractZero; dims=:) = z
 Base.reshape(z::AbstractZero, size...) = z

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -46,9 +46,6 @@ end
 for T in (:Symmetric, :Hermitian)
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero, uplo=:U) = z
 end
-LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractZero, uplo::Symbol) = NoTangent()
-LinearAlgebra.Bidiagonal(dv::AbstractArray, ev::AbstractZero, uplo::Symbol) = Bidiagonal(dv, zero(dv)[1:end-1], uplo)
-LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractArray, uplo::Symbol) = Bidiagonal(vcat(zero(ev), false), ev, uplo)
 
 """
     ZeroTangent() <: AbstractZero

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -42,6 +42,7 @@ for T in (
         :UpperTriangular, :LowerTriangular, :UpperHessenberg,
         :UnitUpperTriangular, :UnitLowerTriangular,
     )
+    VERSION < v"1.4" && f == :UpperHessenberg && continue  # not defined in 1.0
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero) = z
 end
 

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -40,12 +40,42 @@ LinearAlgebra.transpose(z::AbstractZero, ind...) = z
 for T in (
         :UniformScaling, :Adjoint, :Transpose, :Diagonal
         :UpperTriangular, :LowerTriangular, :UnitUpperTriangular, :UnitLowerTriangular,
+        :UpperHessenberg
     )
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero) = z
 end
 for T in (:Symmetric, :Hermitian)
     @eval (::Type{<:LinearAlgebra.$T})(z::AbstractZero, uplo=:U) = z
 end
+
+LinearAlgebra.Bidiagonal(dv::AbstractVector, ev::AbstractZero, uplo::Symbol) = Diagonal(dv)
+function LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractVector, uplo::Symbol)
+    dv = fill!(similar(ev, length(ev) + 1), 0) # can't avoid making a dummy array
+    Bidiagonal(dv, convert(typeof(dv), ev), uplo)
+end
+LinearAlgebra.Bidiagonal(dv::AbstractZero, ev::AbstractZero, uplo::Symbol) = NoTangent()
+
+# one Zero:
+LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractVector, du::AbstractZero) = Diagonal(d)
+LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractVector, du::AbstractVector) = Bidiagonal(d, du, :U)
+LinearAlgebra.Tridiagonal(dl::AbstractVector, d::AbstractVector, du::AbstractZero) = Bidiagonal(d, dl, :L)
+function LinearAlgebra.Tridiagonal(dl::AbstractVector, d::AbstractZero, du::AbstractVector)
+    d = fill!(similar(dl, length(dl) + 1), 0)
+    Tridiagonal(convert(typeof(d), dl), d, convert(typeof(d), du))
+end
+# two Zeros:
+LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractVector, du::AbstractZero) = Diagonal(d)
+LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractZero, du::AbstractVector) = Bidiagonal(d, du, :U)
+LinearAlgebra.Tridiagonal(dl::AbstractVector, d::AbstractZero, du::AbstractZero) = Bidiagonal(d, dl, :L)
+# three Zeros:
+LinearAlgebra.Tridiagonal(dl::AbstractZero, d::AbstractZero, du::AbstractZero) = NoTangent()
+
+LinearAlgebra.SymTridiagonal(dv::AbstractVector, ev::AbstractZero) = Diagonal(dv)
+function LinearAlgebra.SymTridiagonal(dv::AbstractZero, ev::AbstractVector)
+    dv = fill!(similar(ev, length(ev) + 1), 0)
+    SymTridiagonal(dv, convert(typeof(dv), ev))
+end
+LinearAlgebra.SymTridiagonal(dv::AbstractZero, ev::AbstractZero) = NoTangent()
 
 """
     ZeroTangent() <: AbstractZero

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -287,9 +287,11 @@ struct NoSuperType end
         @test pupp(rand(ComplexF32, 3, 3, 1)) isa UpperTriangular{Float64}
         @test ProjectTo(UpperTriangular(randn(3, 3) .> 0))(randn(3, 3)) == NoTangent()
 
-        phess = ProjectTo(UpperHessenberg(rand(3, 3)))
-        @test phess(reshape(1:9,3,3)) == [1 4 7; 2 5 8; 0 6 9]
-        @test phess(reshape(1:9,3,3) .+ im) isa UpperHessenberg{Float64}
+        if VERSION >= v"1.4" # not sure 1.4 exactly!
+            phess = ProjectTo(UpperHessenberg(rand(3, 3)))
+            @test phess(reshape(1:9,3,3)) == [1 4 7; 2 5 8; 0 6 9]
+            @test phess(reshape(1:9,3,3) .+ im) isa UpperHessenberg{Float64}
+        end
 
         pdu = ProjectTo(UnitLowerTriangular(rand(3, 3)))
         # NB, since the diagonal is constant 1, its gradient is zero:

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -232,6 +232,10 @@ struct NoSuperType end
         @test padj_complex(transpose([4, 5, 6 + 7im])) == [4 5 6 + 7im]
         @test padj_complex(adjoint([4, 5, 6 + 7im])) == [4 5 6 - 7im]
 
+        # structural => natural
+        @test padj(Tangent{adjT}(; parent=ones(3) .+ im)) isa adjT
+        @test_skip padj(Tangent{Any}(; parent=ones(3))) isa adjT  # only for Adjoint now
+
         # evil test case
         if VERSION >= v"1.7-"  # up to 1.6  Vector[[1,2,3]]'  is an error, not sure why it's called
             xs = adj(Any[Any[1, 2, 3], Any[4 + im, 5 - im, 6 + im, 7 - im]])
@@ -266,6 +270,10 @@ struct NoSuperType end
         @test psymm(psymm(reshape(1:9, 3, 3))) == psymm(reshape(1:9, 3, 3))
         @test psymm(rand(ComplexF32, 3, 3, 1)) isa Symmetric{Float64}
         @test ProjectTo(Symmetric(randn(3, 3) .> 0))(randn(3, 3)) == NoTangent() # Bool
+        # structural => natural
+        dx = Tangent{typeof(Symmetric(rand(3, 3)))}(; data=[1 2 3; 4 5 6; 7 8 9im])
+        @test psymm(dx) isa Symmetric{Float64}
+        @test psymm(Tangent{typeof(Symmetric(rand(3, 3)))}(; )) isa AbstractZero
 
         pherm = ProjectTo(Hermitian(rand(3, 3) .+ im, :L))
         # NB, projection onto Hermitian subspace, not application of Hermitian constructor
@@ -292,6 +300,8 @@ struct NoSuperType end
         @test pdiag(Diagonal(1.0:3.0)) === Diagonal(1.0:3.0)
         @test ProjectTo(Diagonal(randn(3) .> 0))(randn(3, 3)) == NoTangent()
         @test ProjectTo(Diagonal(randn(3) .> 0))(Diagonal(rand(3))) == NoTangent()
+        # structural => natural
+        @test pdiag(Tangent{typeof(Diagonal(1:3))}(; diag=ones(3) .+ im)) isa Diagonal{Float64}
 
         pbi = ProjectTo(Bidiagonal(rand(3, 3), :L))
         @test pbi(reshape(1:9, 3, 3)) == [1.0 0.0 0.0; 2.0 5.0 0.0; 0.0 6.0 9.0]

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -287,6 +287,16 @@ struct NoSuperType end
         @test pupp(rand(ComplexF32, 3, 3, 1)) isa UpperTriangular{Float64}
         @test ProjectTo(UpperTriangular(randn(3, 3) .> 0))(randn(3, 3)) == NoTangent()
 
+        phess = ProjectTo(UpperHessenberg(rand(3, 3)))
+        @test phess(reshape(1:9,3,3)) == [1 4 7; 2 5 8; 0 6 9]
+        @test phess(reshape(1:9,3,3) .+ im) isa UpperHessenberg{Float64}
+
+        pdu = ProjectTo(UnitLowerTriangular(rand(3, 3)))
+        # NB, since the diagonal is constant 1, its gradient is zero:
+        @test pdu(reshape(1:9, 3, 3)) == [0 0 0; 2 0 0; 3 6 0]
+        @test pdu(rand(ComplexF32, 3, 3, 1)) isa LowerTriangular{Float64}
+        @test pdu(Diagonal(1:3)) == NoTangent()
+
         # an experiment with allowing subspaces which aren't subtypes
         @test psymm(Diagonal([1, 2, 3])) isa Diagonal{Float64}
         @test pupp(Diagonal([1, 2, 3 + 4im])) isa Diagonal{Float64}

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -325,12 +325,23 @@ struct NoSuperType end
         stri = SymTridiagonal(Symmetric(rand(3, 3) .+ im))
         @test pstri(stri) == real(stri)
         @test_throws DimensionMismatch pstri(rand(ComplexF32, 3, 2))
+        # structural => natural
+        pstri(Tangent{SymTridiagonal}(ev = [1,2])) # matrix
+        # subspace but not a subtype:
+        @test pstri(Tangent{SymTridiagonal}(dv = [1, 2, 3])) isa Diagonal{Float64}
+        @test pstri(Diagonal(rand(3) .+ im)) isa Diagonal{Float64}
 
         ptri = ProjectTo(Tridiagonal(rand(3, 3)))
         @test ptri(reshape(1:9, 3, 3)) == [1.0 4.0 0.0; 2.0 5.0 8.0; 0.0 6.0 9.0]
         @test ptri(ptri(reshape(1:9, 3, 3))) == ptri(reshape(1:9, 3, 3))
         @test ptri(rand(ComplexF32, 3, 3)) isa Tridiagonal{Float64}
-        @test_throws DimensionMismatch ptri(rand(ComplexF32, 3, 2))
+        @test_throws ArgumentError ptri(rand(ComplexF32, 3, 2))
+        # structural => natural
+        ptri(Tangent{Tridiagonal}(du = [1, 2], dl = [3im, 4im])) isa Tridiagonal{Float64}
+        # subspace but not a subtype:
+        ptri(Tangent{Tridiagonal}(du = [1, 2])) isa Bidiagonal{Float64}
+        ptri(Tangent{Tridiagonal}(du = [1, 2], d = [3im, 4im, 5im])) isa Bidiagonal{Float64}
+        ptri(Tangent{Tridiagonal}(d = [1, 2, 3])) isa Diagonal{Float64}
     end
 
     #####

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -312,6 +312,11 @@ struct NoSuperType end
         bu = Bidiagonal(rand(3, 3) .+ im, :U)  # differs but uplo, not type
         @test pbi(bu) == diagm(0 => diag(real(bu)))
         @test_throws DimensionMismatch pbi(rand(ComplexF32, 3, 2))
+        # structural => natural
+        @test pbi(Tangent{Bidiagonal}(; ev=(1:2.0))) isa Bidiagonal  # constructs the diagonal
+        # subspace but not a subtype:
+        @test pbi(Tangent{Bidiagonal}(; dv=[1,2,3+im])) isa Diagonal{Float64}
+        @test pbi(Diagonal(1:3)) isa Diagonal{Float64}
 
         pstri = ProjectTo(SymTridiagonal(Symmetric(rand(3, 3))))
         @test pstri(reshape(1:9, 3, 3)) == [1.0 3.0 0.0; 3.0 5.0 7.0; 0.0 7.0 9.0]

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -287,11 +287,9 @@ struct NoSuperType end
         @test pupp(rand(ComplexF32, 3, 3, 1)) isa UpperTriangular{Float64}
         @test ProjectTo(UpperTriangular(randn(3, 3) .> 0))(randn(3, 3)) == NoTangent()
 
-        if VERSION >= v"1.4" # not sure 1.4 exactly!
-            phess = ProjectTo(UpperHessenberg(rand(3, 3)))
-            @test phess(reshape(1:9,3,3)) == [1 4 7; 2 5 8; 0 6 9]
-            @test phess(reshape(1:9,3,3) .+ im) isa UpperHessenberg{Float64}
-        end
+        phess = ProjectTo(UpperHessenberg(rand(3, 3)))
+        @test phess(reshape(1:9,3,3)) == [1 4 7; 2 5 8; 0 6 9]
+        @test phess(reshape(1:9,3,3) .+ im) isa UpperHessenberg{Float64}
 
         pdu = ProjectTo(UnitLowerTriangular(rand(3, 3)))
         # NB, since the diagonal is constant 1, its gradient is zero:
@@ -494,7 +492,7 @@ struct NoSuperType end
         @test eval(Meta.parse(str))(ones(1, 3)) isa Adjoint{Float64,Vector{Float64}}
     end
 
-    VERSION > v"1.1" && @testset "allocation tests" begin
+    @testset "allocation tests" begin
         # For sure these fail on Julia 1.0, not sure about 1.3 etc.
         # We only really care about current stable anyway
         # Each "@test 33 > ..." is zero on nightly, 32 on 1.5.

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -322,6 +322,7 @@ struct NoSuperType end
         bu = Bidiagonal(rand(3, 3) .+ im, :U)  # differs but uplo, not type
         @test pbi(bu) == diagm(0 => diag(real(bu)))
         @test_throws DimensionMismatch pbi(rand(ComplexF32, 3, 2))
+        @test ProjectTo(Bidiagonal(randn(3, 3) .> 0, :L))(rand(3, 3)) == NoTangent()
         # structural => natural
         @test pbi(Tangent{Bidiagonal}(; ev=(1:2.0))) isa Bidiagonal  # constructs the diagonal
         # subspace but not a subtype:
@@ -345,7 +346,7 @@ struct NoSuperType end
         @test ptri(reshape(1:9, 3, 3)) == [1.0 4.0 0.0; 2.0 5.0 8.0; 0.0 6.0 9.0]
         @test ptri(ptri(reshape(1:9, 3, 3))) == ptri(reshape(1:9, 3, 3))
         @test ptri(rand(ComplexF32, 3, 3)) isa Tridiagonal{Float64}
-        @test_throws ArgumentError ptri(rand(ComplexF32, 3, 2))
+        @test_throws DimensionMismatch ptri(rand(ComplexF32, 3, 2))
         # structural => natural
         ptri(Tangent{Tridiagonal}(du = [1, 2], dl = [3im, 4im])) isa Tridiagonal{Float64}
         # subspace but not a subtype:

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -307,6 +307,7 @@ struct NoSuperType end
     @testset "LinearAlgebra: sparse structured matrices" begin
         pdiag = ProjectTo(Diagonal(1:3))
         @test pdiag(reshape(1:9, 3, 3)) == Diagonal([1, 5, 9])
+        @test pdiag(reshape(1:9, 3, 3, 1)) == Diagonal([1, 5, 9])
         @test pdiag(pdiag(reshape(1:9, 3, 3))) == pdiag(reshape(1:9, 3, 3))
         @test pdiag(rand(ComplexF32, 3, 3)) isa Diagonal{Float64}
         @test pdiag(Diagonal(1.0:3.0)) === Diagonal(1.0:3.0)

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -5,6 +5,9 @@
     end
 
     @testset "Linear operators" begin
+        @test getindex(ZeroTangent(), 1) === ZeroTangent()
+        @test getindex(NoTangent(), 1, 2) === NoTangent()
+
         @test view(ZeroTangent(), 1) == ZeroTangent()
         @test view(NoTangent(), 1, 2) == NoTangent()
 

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -160,5 +160,27 @@
         @test Transpose(ZeroTangent()) === ZeroTangent()
         @test Symmetric(ZeroTangent()) === ZeroTangent()
         @test Hermitian(ZeroTangent(), :U) === ZeroTangent()
+
+        # Multidiagonal
+        @test Bidiagonal([1, 2, 3], ZeroTangent(), :U) == Diagonal(1:3)
+        @test Bidiagonal(ZeroTangent(), 1:3, :U) == [0 1 0 0; 0 0 2 0; 0 0 0 3; 0 0 0 0]
+        @test Tridiagonal(ZeroTangent(), ZeroTangent(), [4, 5]) == [0 4 0; 0 0 5; 0 0 0]
+        @test Tridiagonal(ZeroTangent(), 1:3, ZeroTangent()) == Diagonal(1:3)
+    end
+
+    @testset "promote vectors" begin
+        v64s = (Vector{Float64}, Vector{Float64})
+        @test v64s == typeof.(ChainRulesCore._promote_vectors(fill(pi,3), [1,2,3]))
+        @test v64s == typeof.(ChainRulesCore._promote_vectors(Any[1,2,pi], rand(2)))
+        @test v64s == typeof.(ChainRulesCore._promote_vectors(randn(3) .> 1, rand(10)))
+
+        @test length.(ChainRulesCore._promote_vectors(Any[1,2,pi], rand(2))) == (3, 2)
+        @test length.(ChainRulesCore._promote_vectors(randn(3) .> 1, rand(10))) == (3, 10)
+
+        _samet((x, y)) = typeof(x) == typeof(y)
+        @test _samet(ChainRulesCore._promote_vectors(sparse([1,0,3]), [4,5,6]))
+        @test _samet(ChainRulesCore._promote_vectors(SA[1/2, 3/4], [5, 6]))
+        # The last isn't actually realistic, since all the constructors which take several
+        # vectors demand both same type and different length, so cannot accept StaticArrays.
     end
 end

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -149,4 +149,13 @@
         end
         @test isempty(detect_ambiguities(M))
     end
+
+    @testset "LinearAlgebra constructors" begin
+        @test adjoint(ZeroTangent()) === ZeroTangent()
+        @test transpose(ZeroTangent()) === ZeroTangent()
+        @test Adjoint(ZeroTangent()) === ZeroTangent()
+        @test Transpose(ZeroTangent()) === ZeroTangent()
+        @test Symmetric(ZeroTangent()) === ZeroTangent()
+        @test Hermitian(ZeroTangent(), :U) === ZeroTangent()
+    end
 end


### PR DESCRIPTION
The example from https://github.com/JuliaDiff/ChainRulesCore.jl/issues/441#issuecomment-902941440 is `x -> sqrt(Diagonal(x))`, whose implementation is `sqrt.(x.diag)`. At present, Zygote returns a "structural" tangent for this, i.e. a NamedTuple. When the `.diag` is the very first operation being performed, this is returned, but if it occurs after other operations, then their gradients will tend not to understand this.

This PR proposes that there should be a method `ProjectTo{Diagonal}(::Tangent)` which converts this back to the "natural" form, i.e. to another Diagonal. To try it out:
```julia
# ] dev ChainRulesCore
using Zygote, ChainRulesCore, LinearAlgebra

gradient(x -> sum(sqrt.(x.diag)), Diagonal([1,2,3]))  # returns a NamedTuple containing a vector.
gradient(x -> sum(sqrt.((cbrt.(x)).diag)), Diagonal([1,2,3]))  # gradient of cbrt.(x) fails 

# Instead of hacking the gradient for getproperty, for now insert this:
function ChainRulesCore.rrule(::typeof(identity), x::AbstractArray)
  x, dx -> (NoTangent(), ProjectTo(x)(dx))
end

gradient(x -> sum(sqrt.(identity(x).diag)), Diagonal([1,2,3]))[1]  # returns a Diagonal
gradient(x -> sum(sqrt.((identity(cbrt.(x))).diag)), Diagonal([1,2,3]))[1]  # works!
# Note these print T = Any, from (::Tangent{T}) where T = (@show T; ...)
```
There ~~are~~ were two immediate hurdles here. ~~One is that, to work with Base's `sqrt(::Diagonal)` method, you would have to insert a projection step into Zygote's `litereal_getproperty` adjoint definition. It's not immediately obvious to me how to do that.~~ Done in https://github.com/FluxML/Zygote.jl/pull/1104

~~The second is that Zygote makes a `Tangent{Any}` here. I thought that `dx::Tangent{T}` was supposed to always have `typeof(x) == T` exactly. If that's not true, then must we worry about getting a `Tangent` which doesn't come from a Diagonal at all?~~ See below, I guess this wants https://github.com/FluxML/Zygote.jl/pull/1057 

I added a similar line for UpperTriangular. At present `x::UpperTriangular` accepts `dx::Diagonal` as a "natural" gradient. If it must accept `dx::Tangent{Diagonal}` too, well we could write a method for that. But how generally that can work I don't know. I'm not sure it's worth trying.

Beyond the immediate, this is still an easy case of the problems discussed in #441 (not 411, sorry!), in that the Tangent contains a Vector and can trivially be re-wrapped to form a Diagonal. (Before finding this `Any`, I was trying to make dispatch restrict it to this case.) It doesn't address what should happen if the content of the `Tangent{Diagonal}` is some other weird structural thing, which cannot itself be ProjectTo'd to an AbstractVector -- that's what we don't have concrete examples of yet.

Edit -- this particular example is now handled explicitly by https://github.com/JuliaDiff/ChainRules.jl/pull/509.

Edit' -- the `Tangent{Any}` isn't an inference failure, it's explicitly constructed that way because the input NamedTuple doesn't have the type, here:
https://github.com/FluxML/Zygote.jl/blob/05d0c2ae04f334a2ec61e42decfe1172d0f2e6e8/src/compiler/chainrules.jl#L126-L129