### PR TITLE
Add StatsFuns to integration tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -24,6 +24,7 @@ jobs:
           - {user: SciML, repo: DiffEqBase.jl}
           - {user: PumasAI, repo: DataInterpolations.jl}
           - {user: dfdx, repo: Yota.jl}
+          - {user: JuliaStats, repo: StatsFuns.jl}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
StatsFuns 0.9.10 (released yesterday) uses CR 1. It has 655 dependents (93 direct ones) (https://juliahub.com/ui/Packages/StatsFuns/530lR/0.9.10?t=2) and therefore I think it could be useful to add it to the integration tests.