### PR TITLE
Add `derivatives_given_output` for scalar functions

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -156,12 +156,20 @@ end
 """
     derivatives_given_output(Ω, f, xs...)
 
-Compute the derivative of scalar function `f` at primal input point `xs...`, given that it had primal output `Ω`.
-This is used within the implementation of [`@scalar_rule`](@ref) and is not
-considered part of the stable API.
-It returns a tuple of tuples with the partial derivatives of `f` with respect to the `xs`.
-The derivative of the `i`-th component of `f` with respect to the `j`-th input can be accessed
-as `Df[i][j]`, where `Df = derivatives_given_output(Ω, f, xs...)`.
+Compute the derivative of scalar function `f` at primal input point `xs...`,
+given that it had primal output `Ω`.
+Return a tuple of tuples with the partial derivatives of `f` with respect to the `xs...`.
+The derivative of the `i`-th component of `f` with respect to the `j`-th input can be
+accessed as `Df[i][j]`, where `Df = derivatives_given_output(Ω, f, xs...)`.
+
+!!! warning "Experimental"
+    This function is experimental and not part of the stable API.
+    At the moment, it can be considered an implementation detail of the macro
+    [`@scalar_rule`](@ref), in which it is used.
+    In the future, the exact semantics of this function will stabilize, and it
+    will be added to the stable API.
+    When that happens, this warning will be removed.
+
 """
 function derivatives_given_output end
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -159,8 +159,9 @@ end
 Compute the derivative of scalar function `f` with inputs `xs...` and output `Ω`.
 This is used within the implementation of [`@scalar_rule`](@ref) and is not
 considered part of the stable API.
-If the output is scalar, return a tuple with partial derivatives with respect to the `xs`.
-If the output is a tuple, return a tuple of tuples.
+It returns a tuple of tuples with the partial derivatives of `f` with respect to the `xs`.
+The derivative of the `i`-th component of `f` with respect to the `j`-th input can be accessed
+as `Df[i][j]`, where `Df = derivatives_given_output(Ω, f, xs...)`.
 """
 function derivatives_given_output end
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -90,7 +90,7 @@ macro scalar_rule(call, maybe_setup, partials...)
 
     # Generate variables to store derivatives named dfi/dxj
     derivatives = map(keys(partials)) do i
-        syms = map(j -> Symbol("∂f", i, "/∂x", j)), keys(inputs)
+        syms = map(j -> Symbol("∂f", i, "/∂x", j), keys(inputs))
         return Expr(:tuple, syms...)
     end
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -90,7 +90,7 @@ macro scalar_rule(call, maybe_setup, partials...)
 
     # Generate variables to store derivatives named dfi/dxj
     derivatives = map(keys(partials)) do i
-        syms = map(j -> esc(gensym(Symbol("df", i, "/dx", j))), keys(inputs))
+        syms = map(j -> Symbol("∂f", i, "/∂x", j)), keys(inputs)
         return Expr(:tuple, syms...)
     end
 

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -156,7 +156,7 @@ end
 """
     derivatives_given_output(Ω, f, xs...)
 
-Compute the derivative of scalar function `f` with inputs `xs...` and output `Ω`.
+Compute the derivative of scalar function `f` at primal input point `xs...`, given that it had primal output `Ω`.
 This is used within the implementation of [`@scalar_rule`](@ref) and is not
 considered part of the stable API.
 It returns a tuple of tuples with the partial derivatives of `f` with respect to the `xs`.

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -235,6 +235,9 @@ end
             @test ẏ == Tangent{typeof(y)}(50f0, 100f0)
             # make sure type is exactly as expected:
             @test ẏ isa Tangent{Tuple{Irrational{:π}, Float64}, Tuple{Float32, Float32}}
+
+            xs, Ω = (3,), (3, 6)
+            @test ChainRulesCore.derivatives_given_output(Ω, simo, xs...) == ((1f0,), (2f0,))
         end
 
         @testset "@scalar_rule projection" begin
@@ -298,7 +301,7 @@ module IsolatedModuleForTestingScoping
     module IsolatedSubmodule
         # check that rules defined in isolated module without imports can be called
         # without errors
-        using ChainRulesCore: frule, rrule, ZeroTangent, NoTangent
+        using ChainRulesCore: frule, rrule, ZeroTangent, NoTangent, derivatives_given_output
         using ..IsolatedModuleForTestingScoping: fixed, fixed_kwargs, my_id
         using Test
 
@@ -328,6 +331,8 @@ module IsolatedModuleForTestingScoping
             y, f_pullback = rrule(my_id, x)
             @test y == x
             @test f_pullback(Δy) == (NoTangent(), Δy)
+
+            @test derivatives_given_output(y, my_id, x) == ((1.0,),)
         end
     end
 end


### PR DESCRIPTION
This follows up on the discussion on Slack. It is a small refactor of `@scalar_rule` such that the actual derivative computation is factored out in an (internal) method

```julia
derivatives_given_output(Ω, f, xs...) # not sure about the signature, but this seemed reasonable
```

This allows some optimization if one happens to have both `xs` and `Ω` and does not want to recompute `f` to get derivatives. 

This does fix https://github.com/JuliaDiff/ChainRulesCore.jl/issues/246 in its original formulation (getting derivative without running primal pass for scalar rules). It is specific to scalar rules, it does not try to define a general API for `frule` and `rrule` when the output is known.

Notes:

- The second commit does a small `esc` fix, in that `_normalize_scalarrules_macro_input` was "lying" about correctly escaping everything. It was not escaping `partials`, which were instead escaped in `propagation_expr`. That caused some complications in this refactor, so I fixed it.
- Still needs bumping version number. I'm not sure if it should be 1.4.1 or 1.3.2.

EDIT: I've also added some tests of using `derivatives_given_output` independently of `frule` and `rrule`