### PR TITLE
Run integration tests on latest stable julia release

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.5]
+        julia-version: [1]
         os: [ubuntu-latest]
         package:
           - {user: JuliaDiff, repo: ChainRules.jl}


### PR DESCRIPTION
1.5 is old.
Some of our downstream doesn't support it as well.
E.g. ChainRules.jl only promises that things will pass the type inference checks on the latest release.
Which currently our reverse dep test fail because they are testing 1.5 where the ChainRules.jl tests fail at inference.
We could disable those inference tests, but we actually don't want to, since if a ChainRulesCore change breaks inference in ChainRules.jl then we want to know about it.

