### PR TITLE
Add `ProjectTo(::Any) = identity`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -84,7 +84,8 @@ Returns a `ProjectTo{T}` functor which projects a differential `dx` onto the
 relevant tangent space for `x`.
 
 At present this undersands only `x::Number`, `x::AbstractArray` and `x::Ref`.
-It should not be called on arguments of an `rrule` method which accepts other types.
+Called on unknown types it will now simply return `identity`, thus can be safely
+applied to arbitrary `rrule` arguments.
 
 # Examples
 ```jldoctest
@@ -112,7 +113,7 @@ julia> ProjectTo([1 2; 3 4]')  # no special structure, integers are promoted to 
 ProjectTo{AbstractArray}(element = ProjectTo{Float64}(), axes = (Base.OneTo(2), Base.OneTo(2)))
 ```
 """
-ProjectTo(::Any) # just to attach docstring
+ProjectTo(::Any) = identity
 
 # Generic
 (::ProjectTo{T})(dx::AbstractZero) where {T} = dx
@@ -142,6 +143,11 @@ ProjectTo{P}(::NamedTuple{T, <:Tuple{_PZ, Vararg{<:_PZ}}}) where {P,T} = Project
 
 # Bool
 ProjectTo(::Bool) = ProjectTo{NoTangent}()  # same projector as ProjectTo(::AbstractZero) above
+
+# Other never-differentiable types
+for T in [:Symbol, :Char, :AbstractString, :RoundingMode, :IndexStyle]
+    @eval ProjectTo(::$T) = ProjectTo{NoTangent}()
+end
 
 # Numbers
 ProjectTo(::Real) = ProjectTo{Real}()

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -83,8 +83,9 @@ _maybe_call(f, x) = f
 Returns a `ProjectTo{T}` functor which projects a differential `dx` onto the
 relevant tangent space for `x`.
 
-At present this undersands only `x::Number`, `x::AbstractArray` and `x::Ref`.
-Called on unknown types it will now simply return `identity`, thus can be safely
+Custom `ProjectTo` methods are provided for many subtypes of `Number` (to e.g. ensure precision),
+and `AbstractArray` (to e.g. ensure sparsity structure is maintained by tangent).
+Called on unknown types it will (as of v1.5.0) simply return `identity`, thus can be safely
 applied to arbitrary `rrule` arguments.
 
 # Examples
@@ -145,7 +146,7 @@ ProjectTo{P}(::NamedTuple{T, <:Tuple{_PZ, Vararg{<:_PZ}}}) where {P,T} = Project
 ProjectTo(::Bool) = ProjectTo{NoTangent}()  # same projector as ProjectTo(::AbstractZero) above
 
 # Other never-differentiable types
-for T in [:Symbol, :Char, :AbstractString, :RoundingMode, :IndexStyle]
+for T in (:Symbol, :Char, :AbstractString, :RoundingMode, :IndexStyle)
     @eval ProjectTo(::$T) = ProjectTo{NoTangent}()
 end
 


### PR DESCRIPTION
Closes #442, I think. 

Besides `ProjectTo(::Any) = identity`, this also adds a few methods marking things like `Symbol, Char` as non-differentiable. Could also just leave them alone. 