### PR TITLE
fix `getproperty(::Tangent, ::Int)` for NamedTuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -68,13 +68,16 @@ function Base.show(io::IO, comp::Tangent{P}) where P
     end
 end
 
-function Base.getindex(comp::Tangent, idx::Int)
+function Base.getindex(comp::Tangent{P, T}, idx::Int) where {P, T<:Union{Tuple, NamedTuple}}
     back = backing(canonicalize(comp))
     return unthunk(getfield(back, idx))
 end
 function Base.getindex(comp::Tangent{P, T}, idx::Symbol) where {P, T<:NamedTuple}
     hasfield(T, idx) || return ZeroTangent()
     return unthunk(getfield(backing(comp), idx))
+end
+function Base.getindex(comp::Tangent, idx) where {P, T<:AbstractDict}
+    return unthunk(getindex(backing(comp), idx))
 end
 
 function Base.getproperty(comp::Tangent, idx::Int)

--- a/src/differentials/composite.jl
+++ b/src/differentials/composite.jl
@@ -68,15 +68,22 @@ function Base.show(io::IO, comp::Tangent{P}) where P
     end
 end
 
-Base.getindex(comp::Tangent, idx) = getindex(backing(comp), idx)
-
-# for Tuple
-Base.getproperty(comp::Tangent, idx::Int) = unthunk(getproperty(backing(comp), idx))
-function Base.getproperty(
-    comp::Tangent{P, T}, idx::Symbol
-) where {P, T<:NamedTuple}
+function Base.getindex(comp::Tangent, idx::Int)
+    back = backing(canonicalize(comp))
+    return unthunk(getfield(back, idx))
+end
+function Base.getindex(comp::Tangent{P, T}, idx::Symbol) where {P, T<:NamedTuple}
     hasfield(T, idx) || return ZeroTangent()
-    return unthunk(getproperty(backing(comp), idx))
+    return unthunk(getfield(backing(comp), idx))
+end
+
+function Base.getproperty(comp::Tangent, idx::Int)
+    back = backing(canonicalize(comp))
+    return unthunk(getfield(back, idx))
+end
+function Base.getproperty(comp::Tangent{P, T}, idx::Symbol) where {P, T<:NamedTuple}
+    hasfield(T, idx) || return ZeroTangent()
+    return unthunk(getfield(backing(comp), idx))
 end
 
 Base.keys(comp::Tangent) = keys(backing(comp))

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -54,9 +54,20 @@ end
 
         @test keys(Tangent{Tuple{Float64,}}(2.0)) == Base.OneTo(1)
         @test propertynames(Tangent{Tuple{Float64,}}(2.0)) == (1,)
+        @test getindex(Tangent{Tuple{Float64,}}(2.0), 1) == 2.0
+        @test getindex(Tangent{Tuple{Float64,}}(@thunk 2.0^2), 1) == 4.0
         @test getproperty(Tangent{Tuple{Float64,}}(2.0), 1) == 2.0
         @test getproperty(Tangent{Tuple{Float64,}}(@thunk 2.0^2), 1) == 4.0
-        @test getproperty(Tangent{Tuple{Float64,}}(a=(@thunk 2.0^2),), :a) == 4.0
+
+        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :a) == 4.0
+        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
+        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
+        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 2) == 4.0
+
+        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :a) == 4.0
+        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
+        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
+        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 2) == 4.0
 
         # TODO: uncomment this once https://github.com/JuliaLang/julia/issues/35516
         @test_broken haskey(Tangent{Tuple{Float64}}(2.0), 1) == true

--- a/test/differentials/composite.jl
+++ b/test/differentials/composite.jl
@@ -59,15 +59,16 @@ end
         @test getproperty(Tangent{Tuple{Float64,}}(2.0), 1) == 2.0
         @test getproperty(Tangent{Tuple{Float64,}}(@thunk 2.0^2), 1) == 4.0
 
-        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :a) == 4.0
-        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
-        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
-        @test getindex(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 2) == 4.0
+        NT = NamedTuple{(:a, :b), Tuple{Float64, Float64}}
+        @test getindex(Tangent{NT}(a=(@thunk 2.0^2),), :a) == 4.0
+        @test getindex(Tangent{NT}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
+        @test getindex(Tangent{NT}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
+        @test getindex(Tangent{NT}(b=(@thunk 2.0^2),), 2) == 4.0
 
-        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :a) == 4.0
-        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
-        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
-        @test getproperty(Tangent{NamedTuple{(:a, :b), Float64}}(b=(@thunk 2.0^2),), 2) == 4.0
+        @test getproperty(Tangent{NT}(a=(@thunk 2.0^2),), :a) == 4.0
+        @test getproperty(Tangent{NT}(a=(@thunk 2.0^2),), :b) == ZeroTangent()
+        @test getproperty(Tangent{NT}(b=(@thunk 2.0^2),), 1) == ZeroTangent()
+        @test getproperty(Tangent{NT}(b=(@thunk 2.0^2),), 2) == 4.0
 
         # TODO: uncomment this once https://github.com/JuliaLang/julia/issues/35516
         @test_broken haskey(Tangent{Tuple{Float64}}(2.0), 1) == true


### PR DESCRIPTION
also fixes some issues with `getindex`, mainly that it didn't
canonicalize tangents with NamedTuple backing, which I'd argue is a bug.
It's also more consistent with `getproperty` now, so `tangent[:a]`
returns `ZeroTangent()` instead of erroring if `tangent`'s backing
doesn't have a field `a`.

ref JuliaDiff/Diffractor.jl#39
