### PR TITLE
auto-cancel old PR builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,11 @@ on:
     branches: [master]
     tags: ["*"]
   pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -5,6 +5,12 @@ on:
     tags: [v*]
   pull_request:
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: ${{ matrix.package.repo }}

--- a/.github/workflows/JuliaNightly.yml
+++ b/.github/workflows/JuliaNightly.yml
@@ -7,6 +7,11 @@ on:
     branches: [master]
     tags: ["*"]
   pull_request:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
     name: Julia Nightly - Ubuntu - x64


### PR DESCRIPTION
We are beginning to hit concurrency limits of GH actions if there are
many pushes in a row since we do run quite a lot of jobs. This should
automatically cancel the old jobs for a particular PR if there is a more
recent push.

All credit goes to @DilumAluthge.
