### PR TITLE
handle mixed thunks and nonthunks in diagm

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
Also removed piracy, resolving #472 

I orginally set  out to do that.
Then i realized that we didn't support `diagm(1=>@thunk [1,2,3], -1=>[1,2,3])` 
and then this resulted
It is more compilicated than I would like, and I kinda wonder if we should just not support `diagm` at all with thunks?

Only support purely thunked  case, like we currently do?
Which the solution from https://github.com/JuliaDiff/ChainRulesCore.jl/issues/472#issuecomment-930361385 is all we need:
```julia
function LinearAlgebra.diagm(m, n, kv::Pair{<:Integer,<:AbstractThunk}, kvs::Pair{<:Integer,<:AbstractThunk}...) 
     return diagm(m, n, (k => unthunk(v) for (k, v) in (kv, kvs...))...) 
 end 
 ```