### PR TITLE
Add `realconjtimes` and `imagconjtimes` from ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -10,7 +10,10 @@ Private = false
 ## Rule Definition Tools
 ```@autodocs
 Modules = [ChainRulesCore]
-Pages = ["rule_definition_tools.jl"]
+Pages = [
+    "rule_definition_tools.jl",
+    "utils.jl",
+]
 Private = false
 ```
 

--- a/docs/src/complex.md
+++ b/docs/src/complex.md
@@ -87,3 +87,6 @@ end
     There are various notions of complex derivatives (holomorphic and Wirtinger derivatives, Jacobians, gradients, etc.) which differ in subtle but important ways.
     The goal of ChainRules is to provide the basic differentiation rules upon which these derivatives can be implemented, but it does not implement these derivatives itself.
     It is recommended that you carefully check how the above definitions of `frule` and `rrule` translate into your specific notion of complex derivative, since getting this wrong will quietly give you wrong results.
+
+!!! note
+    If you implement `rrule` for a non-holomorphic function, [`realconjtimes`](@ref) and [`imagconjtimes`](@ref) can be useful.

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -16,6 +16,8 @@ export add!!  # gradient accumulation operations
 export ignore_derivatives, @ignore_derivatives
 # differentials
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk
+# helpers for rules with complex numbers
+export realconjtimes, imagconjtimes
 
 include("compat.jl")
 include("debug_mode.jl")
@@ -34,6 +36,7 @@ include("config.jl")
 include("rules.jl")
 include("rule_definition_tools.jl")
 include("ignore_derivatives.jl")
+include("utils.jl")
 
 include("deprecated.jl")
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,15 +1,33 @@
-# real(conj(x) * y) avoiding computing the imaginary part if possible
-@inline _realconjtimes(x, y) = real(conj(x) * y)
-@inline _realconjtimes(x::Complex, y::Complex) = muladd(real(x), real(y), imag(x) * imag(y))
-@inline _realconjtimes(x::Real, y::Complex) = x * real(y)
-@inline _realconjtimes(x::Complex, y::Real) = real(x) * y
-@inline _realconjtimes(x::Real, y::Real) = x * y
+"""
+    realconjtimes(x, y)
 
-# imag(conj(x) * y) avoiding computing the real part if possible
-@inline _imagconjtimes(x, y) = imag(conj(x) * y)
-@inline function _imagconjtimes(x::Complex, y::Complex)
+Compute `real(conj(x) * y)` while avoiding computing the imaginary part if possible.
+
+This function can be useful if you implement a `rrule` for a non-holomorphic function
+on complex numbers.
+
+See also: [`imagconjtimes`](@ref)
+"""
+@inline realconjtimes(x, y) = real(conj(x) * y)
+@inline realconjtimes(x::Complex, y::Complex) = muladd(real(x), real(y), imag(x) * imag(y))
+@inline realconjtimes(x::Real, y::Complex) = x * real(y)
+@inline realconjtimes(x::Complex, y::Real) = real(x) * y
+@inline realconjtimes(x::Real, y::Real) = x * y
+
+"""
+    imagconjtimes(x, y)
+
+Compute `imag(conj(x) * y)` while avoiding computing the real part if possible.
+
+This function can be useful if you implement a `rrule` for a non-holomorphic function
+on complex numbers.
+
+See also: [`realconjtimes`](@ref)
+"""
+@inline imagconjtimes(x, y) = imag(conj(x) * y)
+@inline function imagconjtimes(x::Complex, y::Complex)
     return muladd(-imag(x), real(y), real(x) * imag(y))
 end
-@inline _imagconjtimes(x::Real, y::Complex) = x * imag(y)
-@inline _imagconjtimes(x::Complex, y::Real) = -imag(x) * y
-@inline _imagconjtimes(x::Real, y::Real) = ZeroTangent()
+@inline imagconjtimes(x::Real, y::Complex) = x * imag(y)
+@inline imagconjtimes(x::Complex, y::Real) = -imag(x) * y
+@inline imagconjtimes(x::Real, y::Real) = ZeroTangent()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ using Test
     include("rule_definition_tools.jl")
     include("config.jl")
     include("ignore_derivatives.jl")
+    include("utils.jl")
 
     include("deprecated.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,31 @@
+@testset "utils.jl" begin
+    @testset "conjtimes" begin
+        # custom complex number to test fallback definition
+        struct CustomComplex{T}
+            re::T
+            im::T
+        end
+
+        Base.real(x::CustomComplex) = x.re
+        Base.imag(x::CustomComplex) = x.im
+
+        Base.conj(x::CustomComplex) = CustomComplex(x.re, -x.im)
+
+        Base.:*(a::CustomComplex, b::Number) = CustomComplex(reim((a.re + a.im * im) * b)...)
+        Base.:*(a::Number, b::CustomComplex) = b * a
+        function Base.:*(a::CustomComplex, b::CustomComplex)
+            return CustomComplex(reim((a.re + a.im * im) * (b.re + b.im * im))...)
+        end
+
+        inputs = (randn(), randn(ComplexF64), CustomComplex(reim(randn(ComplexF64))...))
+        for x in inputs, y in inputs
+            @test realconjtimes(x, y) == real(conj(x) * y)
+
+            if x isa Real && y isa Real
+                @test imagconjtimes(x, y) === ZeroTangent()
+            else
+                @test imagconjtimes(x, y) == imag(conj(x) * y)
+            end
+        end
+    end
+end


### PR DESCRIPTION
This PR adds `realconjtimes` and `imagconjtimes`, currently defined in `ChainRules` as `_realconjtimes` and `_imagconjtimes`. These optimizations of `real(conj(x) * y)` and `imag(conj(x) * y)` are useful more generally and could be used e.g. in https://github.com/JuliaMath/SpecialFunctions.jl/pull/350.

I extracted `src/rulesets/Base/utils.jl` (and its history) from ChainRules, renamed the functions, and added some tests and documentation.