### PR TITLE
Simplify arithmetic of `NotImplemented` and treat `NoTangent` like `ZeroTangent`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.7.1"
+version = "1.7.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -40,8 +40,8 @@ for T in (:AbstractThunk, :Tangent, :Any)
     @eval LinearAlgebra.dot(::$T, x::NotImplemented) = x
 end
 
-# other common operations throw an exception
-Base.:+(x::NotImplemented) = throw(NotImplementedException(x))
+# subtraction throws an exception: in AD we add tangents but do not subtract them
+# subtraction happens eg. in gradient descent which can't be performed with `NotImplemented`
 Base.:-(x::NotImplemented) = throw(NotImplementedException(x))
 Base.:-(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 for T in (:ZeroTangent, :NoTangent, :AbstractThunk, :Tangent, :Any)

--- a/test/tangent_types/notimplemented.jl
+++ b/test/tangent_types/notimplemented.jl
@@ -6,76 +6,51 @@
         ni2 = ChainRulesCore.NotImplemented(
             @__MODULE__, LineNumberNode(@__LINE__, @__FILE__), "error2"
         )
-
-        # supported operations (for `@scalar_rule`)
         x, y, z = rand(3)
+
+        # conjugate
         @test conj(ni) === ni
-        @test muladd(ni, y, z) === ni
-        @test muladd(ni, ZeroTangent(), z) == z
-        @test muladd(ni, y, ZeroTangent()) === ni
-        @test muladd(ni, ZeroTangent(), ZeroTangent()) == ZeroTangent()
-        @test muladd(ni, ni2, z) === ni
-        @test muladd(ni, ni2, ZeroTangent()) === ni
-        @test muladd(ni, y, ni2) === ni
-        @test muladd(ni, ZeroTangent(), ni2) === ni2
-        @test muladd(x, ni, z) === ni
-        @test muladd(ZeroTangent(), ni, z) == z
-        @test muladd(x, ni, ZeroTangent()) === ni
-        @test muladd(ZeroTangent(), ni, ZeroTangent()) == ZeroTangent()
-        @test muladd(x, ni, ni2) === ni
-        @test muladd(ZeroTangent(), ni, ni2) === ni2
-        @test muladd(x, y, ni) === ni
-        @test muladd(ZeroTangent(), y, ni) === ni
-        @test muladd(x, ZeroTangent(), ni) === ni
-        @test muladd(ZeroTangent(), ZeroTangent(), ni) === ni
-        @test ni + rand() === ni
-        @test ni + ZeroTangent() === ni
-        @test ni + NoTangent() === ni
-        @test ni + true === ni
-        @test ni + @thunk(x^2) === ni
-        @test rand() + ni === ni
-        @test ZeroTangent() + ni === ni
-        @test NoTangent() + ni === ni
-        @test true + ni === ni
-        @test @thunk(x^2) + ni === ni
+
+        # addition
+        for a in (rand(), NoTangent(), ZeroTangent(), true, @thunk(x^2))
+            @test ni + a === ni
+            @test a + ni === ni
+        end
         @test ni + ni2 === ni
-        @test ni * rand() === ni
-        @test ni * ZeroTangent() == ZeroTangent()
-        @test ZeroTangent() * ni == ZeroTangent()
-        @test dot(ni, ZeroTangent()) == ZeroTangent()
-        @test dot(ZeroTangent(), ni) == ZeroTangent()
+        @test ni2 + ni === ni2
+
+        # multiplication and dot product
+        for a in (rand(), true, @thunk(x^2))
+            @test ni * a === ni
+            @test a * ni === ni
+            @test dot(ni, a) === ni
+            @test dot(a, ni) === ni
+        end
+        for a in (NoTangent(), ZeroTangent())
+            @test ni * a === a
+            @test a * ni === a
+            @test dot(ni, a) === a
+            @test dot(a, ni) === a
+        end
+        @test ni * ni2 === ni
+        @test ni2 * ni === ni2
+        @test dot(ni, ni2) === ni
+        @test dot(ni2, ni) === ni2
+
+        # broadcasting
         @test ni .* rand() === ni
+        @test rand() .* ni === ni
         @test broadcastable(ni) isa Ref{typeof(ni)}
 
         # unsupported operations
         E = ChainRulesCore.NotImplementedException
         @test_throws E +ni
         @test_throws E -ni
-        @test_throws E ni - rand()
-        @test_throws E ni - ZeroTangent()
-        @test_throws E ni - NoTangent()
-        @test_throws E ni - true
-        @test_throws E ni - @thunk(x^2)
-        @test_throws E rand() - ni
-        @test_throws E ZeroTangent() - ni
-        @test_throws E NoTangent() - ni
-        @test_throws E true - ni
-        @test_throws E @thunk(x^2) - ni
+        for a in (rand(), NoTangent(), ZeroTangent(), true, @thunk(x^2))
+            @test_throws E ni - a
+            @test_throws E a - ni
+        end
         @test_throws E ni - ni2
-        @test_throws E rand() * ni
-        @test_throws E NoTangent() * ni
-        @test_throws E true * ni
-        @test_throws E @thunk(x^2) * ni
-        @test_throws E ni * ni2
-        @test_throws E dot(ni, rand())
-        @test_throws E dot(ni, NoTangent())
-        @test_throws E dot(ni, true)
-        @test_throws E dot(ni, @thunk(x^2))
-        @test_throws E dot(rand(), ni)
-        @test_throws E dot(NoTangent(), ni)
-        @test_throws E dot(true, ni)
-        @test_throws E dot(@thunk(x^2), ni)
-        @test_throws E dot(ni, ni2)
         @test_throws E ni / rand()
         @test_throws E rand() / ni
         @test_throws E ni / ni2

--- a/test/tangent_types/notimplemented.jl
+++ b/test/tangent_types/notimplemented.jl
@@ -16,6 +16,7 @@
             @test ni + a === ni
             @test a + ni === ni
         end
+        @test +ni === ni
         @test ni + ni2 === ni
         @test ni2 + ni === ni2
 
@@ -44,7 +45,6 @@
 
         # unsupported operations
         E = ChainRulesCore.NotImplementedException
-        @test_throws E +ni
         @test_throws E -ni
         for a in (rand(), NoTangent(), ZeroTangent(), true, @thunk(x^2))
             @test_throws E ni - a

--- a/test/tangent_types/notimplemented.jl
+++ b/test/tangent_types/notimplemented.jl
@@ -6,13 +6,14 @@
         ni2 = ChainRulesCore.NotImplemented(
             @__MODULE__, LineNumberNode(@__LINE__, @__FILE__), "error2"
         )
-        x, y, z = rand(3)
+        x = rand()
+        thunk = @thunk(x^2)
 
         # conjugate
         @test conj(ni) === ni
 
         # addition
-        for a in (rand(), NoTangent(), ZeroTangent(), true, @thunk(x^2))
+        for a in (true, x, NoTangent(), ZeroTangent(), thunk)
             @test ni + a === ni
             @test a + ni === ni
         end
@@ -21,7 +22,7 @@
         @test ni2 + ni === ni2
 
         # multiplication and dot product
-        for a in (rand(), true, @thunk(x^2))
+        for a in (true, x, thunk)
             @test ni * a === ni
             @test a * ni === ni
             @test dot(ni, a) === ni
@@ -39,20 +40,20 @@
         @test dot(ni2, ni) === ni2
 
         # broadcasting
-        @test ni .* rand() === ni
-        @test rand() .* ni === ni
+        @test ni .* x === ni
+        @test x .* ni === ni
         @test broadcastable(ni) isa Ref{typeof(ni)}
 
         # unsupported operations
         E = ChainRulesCore.NotImplementedException
         @test_throws E -ni
-        for a in (rand(), NoTangent(), ZeroTangent(), true, @thunk(x^2))
+        for a in (true, x, NoTangent(), ZeroTangent(), thunk)
             @test_throws E ni - a
             @test_throws E a - ni
         end
         @test_throws E ni - ni2
-        @test_throws E ni / rand()
-        @test_throws E rand() / ni
+        @test_throws E ni / x
+        @test_throws E x / ni
         @test_throws E ni / ni2
         @test_throws E zero(ni)
         @test_throws E zero(typeof(ni))


### PR DESCRIPTION
This PR simplifies the arithmetic of `NotImplemented`. Mainly, it allows more operations that currently throw errors and it treats `NoTangent` like `ZeroTangent`. The basic rules in this PR are:
- `NotImplemented` always wins `+`
- `NotImplemented` loses `*` and `dot` against `NoTangent` and `ZeroTangent` (allows to ignore non-implemented partial derivatives) and wins `*` and `dot` against other types
- `+`, `*`, and `dot` definitions for `NotImplemented` and a value of a different type are commutative

The main motivation for this PR is to be able to test rules such as https://github.com/JuliaMath/SpecialFunctions.jl/pull/350#discussion_r720585597 more easily with something like
```julia
                test_frule(besselix, nu, x) # derivative is `NotImplemented`
                test_frule(besselix, nu ⊢ NoTangent(), x) # derivative is a number
```
(I checked that it works in my local branch with this PR). Without this PR, one has to specify a `ZeroTangent` to test the non-`NotImplemented` derivative (without this PR, in all other cases a `NotImplemented` is returned) - but                `test_frule(besselix, nu ⊢ ZeroTangent(), x)` will include `nu` in the finite differencing which causes test errors due to incorrect values and mismatching dimensions (if `x` is a complex number). Possibly (some of) these issues could be fixed in some other way, in ChainRulesTestutils or FiniteDifferences. However, I think it makes sense to treat `NoTangent()` and `ZeroTangent()` in the same way when multiplying them with a `NotImplemented` and hence the finite differencing problems can be avoided easily by marking `nu` as non-differentiable with `test_frule(besselix, nu ⊢ NoTangent(), x)`.