### PR TITLE
Add LogExpFunctions to integration tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -31,6 +31,7 @@ jobs:
           - {user: PumasAI, repo: DataInterpolations.jl}
           - {user: dfdx, repo: Yota.jl}
           - {user: JuliaStats, repo: StatsFuns.jl}
+          - {user: JuliaStats, repo: LogExpFunctions.jl}
         # Diffractor needs to run on Julia nightly
         include:
           - julia-version: nightly


### PR DESCRIPTION
Recent versions of LogExpFunctions include derivative definitions with CRC. Since the package has 1574 dependents currently (https://juliahub.com/ui/Packages/LogExpFunctions/cmCYR/0.3.3?t=2; e.g. SpecialFunctions and StatsFuns) I think it would make sense to include it in the integration tests.