### PR TITLE
Minor cleaning of FAQ

### DIFF
--- a/docs/src/FAQ.md
+++ b/docs/src/FAQ.md
@@ -84,6 +84,16 @@ This means your package can depend on the light-weight ChainRulesCore.jl, and ma
 
 Remember to read the section [On writing good `rrule` / `frule` methods](@ref).
 
+## Is removing a thunk a breaking change?
+Removing thunks is not considered a breaking change.
+This is because (in principle) removing them changes the implementation of the values
+returned by an `rrule`, not the value that they represent.
+This is morally the same as similar issues [discussed in ColPrac](https://github.com/SciML/ColPrac#changes-that-are-not-considered-breaking), such as details of floating point arithmetic changing.
+
+On a practical level, it's important that this is the case because thunks are a bit of a hack,
+and over time it is hoped that the need for them will reduce, as they increase
+code-complexity and place additional stress on the compiler.
+
 ## Where can I learn more about AD ?
 There are not so many truly excellent learning resources for autodiff out there in the world, which is a bit sad.
 The list here is incomplete, but is vetted for quality.
@@ -100,15 +110,4 @@ The list here is incomplete, but is vetted for quality.
 
  - [Diff-Zoo Jupyter Notebook Book](https://github.com/MikeInnes/diff-zoo)  (by [Mike Innes](https://github.com/MikeInnes/diff-zoo), has implementations and explanations.
 
- - ["Evaluating Derivatives"](https://dl.acm.org/doi/book/10.5555/1455489) (by Griewank and Walther) is the best book at least for reverse-mode.
-It also covers forward-mode though (by its own admission) not as well, it never mentioned dual numbers which is an unfortunate lack.
-
-## Is removing a thunk a breaking change?
-Removing thunks is not considered a breaking change.
-This is because (in principle) removing them changes the implementation of the values
-returned by an `rrule`, not the value that they represent.
-This is morally the same as similar issues [discussed in ColPrac](https://github.com/SciML/ColPrac#changes-that-are-not-considered-breaking), such as details of floating point arithmetic changing.
-
-On a practical level, it's important that this is the case because thunks are a bit of a hack,
-and over time it is hoped that the need for them will reduce, as they increase
-code-complexity and place additional stress on the compiler.
+ - ["Evaluating Derivatives"](https://dl.acm.org/doi/book/10.5555/1455489) (by Griewank and Walther) is the best book at least for reverse-mode. It also covers forward-mode though (by its own admission) not as well, it never mentioned dual numbers which is an unfortunate lack.


### PR DESCRIPTION
The learn more should always stay last.

An erant line-break was splitting the sentence about forward mode away from the dot point about the vook