### PR TITLE
Add `ProjectTo(::NamedTuple)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.11.1"
+version = "1.11.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
This PR adds `ProjectTo(::NamedTuple)` according to the suggestion by @mcabbott (I added you as a co-author to give credit). I only added two additional more descriptive error messages and some tests, similar to the implementation for `Tuple`s.

Fixes https://github.com/JuliaDiff/ChainRulesCore.jl/issues/511.