### PR TITLE
Run CI on pushs to main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 2 * * *'  # Daily at 2 AM UTC (8 PM CST)
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
   pull_request:
 concurrency:


### PR DESCRIPTION
this is why our dev/latest docs docs haven't been building.

Thanks @nickrobinson251  for pointing out that they weren't