### PR TITLE
Remove major invalidations from ==

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.13.0"
+version = "1.14.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -25,8 +25,6 @@ end
 end
 
 Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
-Base.:(==)(a::AbstractThunk, b) = unthunk(a) == b
-Base.:(==)(a, b::AbstractThunk) = a == unthunk(b)
 
 Base.:(-)(a::AbstractThunk) = -unthunk(a)
 Base.:(-)(a::AbstractThunk, b) = unthunk(a) - b

--- a/test/tangent_types/thunks.jl
+++ b/test/tangent_types/thunks.jl
@@ -5,7 +5,6 @@
 
     @testset "==" begin
         @test @thunk(3.2) == InplaceableThunk(x -> x + 3.2, @thunk(3.2))
-        @test @thunk(3.2) == 3.2
         @test 3.2 == InplaceableThunk(x -> x + 3.2, @thunk(3.2))
     end
 

--- a/test/tangent_types/thunks.jl
+++ b/test/tangent_types/thunks.jl
@@ -5,7 +5,6 @@
 
     @testset "==" begin
         @test @thunk(3.2) == InplaceableThunk(x -> x + 3.2, @thunk(3.2))
-        @test 3.2 == InplaceableThunk(x -> x + 3.2, @thunk(3.2))
     end
 
     @testset "iterate" begin


### PR DESCRIPTION
See https://github.com/JuliaDiff/ChainRulesCore.jl/issues/523 . Seems to only be used for tests according to the PR but it's a major compile time problem, so it doesn't make sense to keep them. This can be marked breaking if it breaks downstream, but it's rather easy to update downstream AD packages for this so the value proposition is pretty clear.