### PR TITLE
Eliminate ambiguity with Number constructors

### DIFF
--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -25,7 +25,7 @@ Base.transpose(z::AbstractZero) = z
 Base.:/(z::AbstractZero, ::Any) = z
 
 Base.convert(::Type{T}, x::AbstractZero) where {T<:Number} = zero(T)
-(::Type{T})(xs::AbstractZero...) where {T<:Number} = zero(T)
+# (::Type{T})(::AbstractZero, ::AbstractZero...) where {T<:Number} = zero(T)
 
 (::Type{Complex})(x::AbstractZero, y::Real) = Complex(false, y)
 (::Type{Complex})(x::Real, y::AbstractZero) = Complex(x, false)

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -116,4 +116,22 @@
         @test convert(Int64, NoTangent()) == 0
         @test convert(Float64, NoTangent()) == 0.0
     end
+
+    @testset "ambiguities" begin
+        M = @eval module M
+            using ChainRulesCore
+
+            struct X{R,S} <: Number
+                a::R
+                b::S
+                hasvalue::Bool
+
+                function X{R,S}(a, b, hv=true) where {R,S}
+                    isa(hv, Bool) || error("must be bool")
+                    return new{R,S}(a, b, hv)
+                end
+            end
+        end
+        @test isempty(detect_ambiguities(M))
+    end
 end


### PR DESCRIPTION
The constructor for `T<:Number` given a vararg number of
`AbstractZero` is ambiguous with any `Number` subtype
having a varargs constructor:

```julia
julia> module M
       using ChainRulesCore

       struct X{R} <: Number
           a::R
           hasvalue::Bool

           function X{R}(a, hv=true) where {R}
               isa(hv, Bool) || error("must be bool")
               return new{R}(a, hv)
           end
       end
       end
Main.M

julia> using Test

julia> detect_ambiguities(M)
5-element Vector{Tuple{Method, Method}}:
 (Main.M.X{R}(a) where R in Main.M at REPL[1]:8, (::Type{T})(x::Base.TwicePrecision) where T<:Number in Base at twiceprecision.jl:255)
 (Main.M.X{R}(a) where R in Main.M at REPL[1]:8, (::Type{T})(x::AbstractChar) where T<:Union{AbstractChar, Number} in Base at char.jl:50)
 ((::Type{T})(xs::ChainRulesCore.AbstractZero...) where T<:Number in ChainRulesCore at /home/tim/.julia/dev/ChainRulesCore/src/tangent_types/abstract_zero.jl:28, Main.M.X{R}(a, hv) where R in Main.M at REPL[1]:8)
 (Main.M.X{R}(a) where R in Main.M at REPL[1]:8, (::Type{T})(x::T) where T<:Number in Core at boot.jl:770)
 ((::Type{T})(xs::ChainRulesCore.AbstractZero...) where T<:Number in ChainRulesCore at /home/tim/.julia/dev/ChainRulesCore/src/tangent_types/abstract_zero.jl:28, Main.M.X{R}(a) where R in Main.M at REPL[1]:8)
```

I couldn't see any reason that method was needed at all, so I
commented it out, with a partial fix in case someone should discover
a need. It was added in #427, so maybe @mcabbott could comment on what it's for?