### PR TITLE
Add `differential_type`, to test for non-differentiability

### DIFF
--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -11,9 +11,9 @@ export RuleConfig, HasReverseMode, NoReverseMode, HasForwardsMode, NoForwardsMod
 export frule_via_ad, rrule_via_ad
 # definition helper macros
 export @non_differentiable, @opt_out, @scalar_rule, @thunk, @not_implemented
-export ProjectTo, canonicalize, unthunk  # tangent operations
+export ProjectTo, differential_type, canonicalize, unthunk  # tangent operations
 export add!!  # gradient accumulation operations
-export ignore_derivatives, @ignore_derivatives, is_non_differentiable
+export ignore_derivatives, @ignore_derivatives
 # tangents
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk
 

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -478,3 +478,13 @@ struct NoSuperType end
         @test_broken 0 == @ballocated $psymm(dx) setup = (dx = Symmetric(rand(10^3, 10^3)))  # 64
     end
 end
+
+@testset "differential_type" begin
+    @test differential_type(true) == differential_type(Bool) == NoTangent
+    @test differential_type(1) == differential_type(Int) == Float64
+    tup = (false, :x, nothing)
+    @test differential_type(tup) == differential_type(typeof(tup)) == NoTangent
+    
+    @test differential_type(NoSuperType()) == differential_type(NoSuperType) == Any
+    @test differential_type(Dual(1,2)) == differential_type(Dual) == Real
+end


### PR DESCRIPTION
This adds a function to check whether a given type is non-differentiable. The purpose is to let you test whether to take the trivial path for some rule.

It goes by whether `ProjectTo(x)` infers to be a trivial projector. This means it should always be costless, rather than iterating through `x = Any[true, false]` it will give up and return `false`.

Possibly this should return something whose type is the indication, like `Val(true)`? Or return one of `AbstractZero / Number / Any`, or some trait struct `IsNonDiff`, seems a bit heavyweight...