### PR TITLE
Make the addition of thunks use `add!!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.3"
+version = "1.15.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/rule_author/writing_good_rules.md
+++ b/docs/src/rule_author/writing_good_rules.md
@@ -71,6 +71,13 @@ Examples being:
 - There is only one derivative being returned, so from the fact that the user called
   `frule`/`rrule` they clearly will want to use that one.
 
+!! Warning
+   If your rule returns the tangent it receives without change (such as `rrule(::typeof(+), xs::AbstractArray)`
+   or some view / wrapper of this (such as `rrule(::typeof(adjoint), x::AbstractMatrix)`
+   then it is unsafe to wrap it in a `@thunk`. This is because gradient accumulation assumes that
+   the result of `unthunk`ing may be mutated for efficiency, but if the same array appears elsewhere,
+   this will give wrong answers.
+
 ## [Structs: constructors and functors](@id structs)
 
 To define an `frule` or `rrule` for a _function_ `foo` we dispatch on the type of `foo`, which is `typeof(foo)`.

--- a/src/accumulation.jl
+++ b/src/accumulation.jl
@@ -31,10 +31,10 @@ function add!!(x::Thunk, y::Thunk)
 end
 
 add!!(x::Thunk, y::InplaceableThunk) = add!!(unthunk(x), y)  # solves ambiguity
-
 add!!(x::InplaceableThunk, y::Thunk) = add!!(unthunk(y), x)
 
 add!!(x::AbstractArray, y::Thunk) = add!!(x, unthunk(y))
+add!!(x::Thunk, y::AbstractArray) = add!!(unthunk(x), y)
 
 function add!!(x::AbstractArray{<:Any,N}, y::AbstractArray{<:Any,N}) where {N}
     return if is_inplaceable_destination(x)

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -116,11 +116,14 @@ Base.complex(::ZeroTangent, ::ZeroTangent) = ZeroTangent()
 Base.complex(::ZeroTangent, i::Real) = complex(oftype(i, 0), i)
 Base.complex(r::Real, ::ZeroTangent) = complex(r)
 
-Base.:+(a::AbstractThunk, b::AbstractThunk) = add!!(a, b)
 Base.:*(a::AbstractThunk, b::AbstractThunk) = unthunk(a) * unthunk(b)
 
-Base.:+(a::AbstractThunk, b::AbstractArray) = add!!(a, b)
-Base.:+(a::AbstractArray, b::AbstractThunk) = add!!(b, a)
+# The result of unthunking is assumed to be safe to mutate:
+Base.:+(a::AbstractThunk, b::AbstractArray) = add!!(unthunk(a), b)
+Base.:+(a::AbstractArray, b::AbstractThunk) = add!!(unthunk(b), a)
+# With two thunks, possibly , `add!!` will chose which one to mutate.
+# This method avoids AbstractThunk, as any new subtypes of that could lead to stackoverflow:
+Base.:+(a::Union{Thunk,InplaceableThunk}, b::Union{Thunk,InplaceableThunk}) = add!!(a, b)
 
 for T in (:Tangent, :Any)
     @eval Base.:+(a::AbstractThunk, b::$T) = unthunk(a) + b

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -116,8 +116,12 @@ Base.complex(::ZeroTangent, ::ZeroTangent) = ZeroTangent()
 Base.complex(::ZeroTangent, i::Real) = complex(oftype(i, 0), i)
 Base.complex(r::Real, ::ZeroTangent) = complex(r)
 
-Base.:+(a::AbstractThunk, b::AbstractThunk) = unthunk(a) + unthunk(b)
+Base.:+(a::AbstractThunk, b::AbstractThunk) = add!!(a, b)
 Base.:*(a::AbstractThunk, b::AbstractThunk) = unthunk(a) * unthunk(b)
+
+Base.:+(a::AbstractThunk, b::AbstractArray) = add!!(a, b)
+Base.:+(a::AbstractArray, b::AbstractThunk) = add!!(b, a)
+
 for T in (:Tangent, :Any)
     @eval Base.:+(a::AbstractThunk, b::$T) = unthunk(a) + b
     @eval Base.:+(a::$T, b::AbstractThunk) = a + unthunk(b)

--- a/test/tangent_types/tangent.jl
+++ b/test/tangent_types/tangent.jl
@@ -109,7 +109,7 @@ end
         @test NoTangent() === @inferred Base.tail(ntang1)
 
         # TODO: uncomment this once https://github.com/JuliaLang/julia/issues/35516
-        if VERSION >= v"1.8-"
+        if hasmethod(haskey, typeof(((1,2), 3)))
             @test haskey(Tangent{Tuple{Float64}}(2.0), 1) == true
         else
             @test_broken haskey(Tangent{Tuple{Float64}}(2.0), 1) == true


### PR DESCRIPTION
This PR wants to use `add!!` to add thunks, which should be safe if the result of `unthunk`ing is always an array we are free to mutate. And it adds `add!!` methods to try to add any pair of thunks the quickest way.  
```julia
julia> using ChainRulesCore, ChainRules, BenchmarkTools

julia> const m100 = rand(128, 100);

julia> th = @thunk -m100;

julia> @btime unthunk($th);  # 100kb
  min 2.521 μs, mean 13.264 μs (2 allocations, 100.05 KiB)

julia> @btime $th + m100;
  min 8.347 μs, mean 27.694 μs (4 allocations, 200.09 KiB)   # before
  min 12.083 μs, mean 19.496 μs (2 allocations, 100.05 KiB)  # after

julia> @btime m100 + $th;
  min 8.486 μs, mean 32.362 μs (4 allocations, 200.09 KiB)
  min 12.000 μs, mean 18.081 μs (2 allocations, 100.05 KiB)

julia> @btime $th + $th;
  min 11.708 μs, mean 53.798 μs (6 allocations, 300.14 KiB)
  min 15.042 μs, mean 42.060 μs (4 allocations, 200.09 KiB)

julia> ith = rrule(sum, m100)[2](1.0)[2];

julia> @btime unthunk($ith.val); 
  min 1.965 μs, mean 13.766 μs (3 allocations, 100.06 KiB)

julia> @btime $th + $ith;
  min 11.417 μs, mean 74.748 μs (7 allocations, 300.16 KiB)
  min 11.750 μs, mean 32.771 μs (2 allocations, 100.05 KiB)

julia> @btime $ith + $th;
  min 11.500 μs, mean 57.503 μs (7 allocations, 300.16 KiB)
  min 11.875 μs, mean 34.882 μs (2 allocations, 100.05 KiB)

julia> @btime $ith + $ith;
  min 10.167 μs, mean 58.167 μs (8 allocations, 300.17 KiB)  # before
  min 10.125 μs, mean 25.396 μs (3 allocations, 100.06 KiB)  # after
```
Closes #529.

Edit: also closes #297, which I didn't see. That proposes the same rule, that any array coming from `unthunk` we should be allowed to mutate.

~~Does not fix the bug that `unthunk(ith)` seems to make 2 copies, not sure why.~~ (This was just my use of an integer by mistake.)