### PR TITLE
Point `Edit on GitHub` link to main branch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,6 +5,8 @@ using Documenter
 using DocThemeIndigo
 using Markdown
 
+const devbranch = "main"
+
 DocMeta.setdocmeta!(
     ChainRulesCore,
     :DocTestSetup,
@@ -28,6 +30,7 @@ makedocs(;
     format=Documenter.HTML(;
         prettyurls=false,
         assets=[indigo],
+        edit_link=devbranch,
         mathengine=MathJax3(
             Dict(
                 :tex => Dict(
@@ -90,5 +93,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaDiff/ChainRulesCore.jl.git", devbranch="main", push_preview=true
+    repo="github.com/JuliaDiff/ChainRulesCore.jl.git", devbranch=devbranch, push_preview=true
 )

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -93,5 +93,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaDiff/ChainRulesCore.jl.git", devbranch=devbranch, push_preview=true
+    repo="github.com/JuliaDiff/ChainRulesCore.jl.git",
+    devbranch=devbranch,
+    push_preview=true,
 )


### PR DESCRIPTION
- fortunately GitHub redirects master -> main
  but we may as well set it explictly to not
  rely on that