### PR TITLE
Improve type stability of `ProjectTo(non-numeric array)`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -207,7 +207,7 @@ _eltype_projectto(::Type{<:Irrational}) = ProjectTo{Real}()
 
 # In other cases, store a projector per element:
 function ProjectTo(xs::AbstractArray)
-    elements = map(ProjectTo, xs)
+    elements = ProjectTo.(xs)
     if elements isa AbstractArray{<:ProjectTo{<:AbstractZero}}
         return ProjectTo{NoTangent}()  # short-circuit if all elements project to zero
     else

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -107,6 +107,10 @@ struct NoSuperType end
         @test Tuple(ProjectTo(Any[1, 2 + 3im])(1:2)) === (1.0, 2.0 + 0.0im)
         @test ProjectTo(Any[true, false]) isa ProjectTo{NoTangent}
 
+        # projecting other things should still infer
+        @inferred ProjectTo([one, one])
+        @inferred ProjectTo(["x", "y"])
+
         # empty arrays
         @test isempty(ProjectTo([])(1:0))
         @test_throws DimensionMismatch ProjectTo(Int[])([2])


### PR DESCRIPTION
Use broadcasting instead of `map` for non-numeric array projectors. This improves type stability when elements hit `ProjectTo(::Any)`.

I found this while trying to use https://github.com/JuliaDiff/ChainRules.jl/blob/v1.35.3/src/rulesets/Base/mapreduce.jl#L425 with a vector of callables. It's unfortunate that inference can't figure out the map call, but at least broadcasting works.