### PR TITLE
Mark some arrays as safe for accumulation

### DIFF
--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -15,7 +15,7 @@ export ProjectTo, canonicalize, unthunk  # tangent operations
 export add!!, is_inplaceable_destination  # gradient accumulation operations
 export ignore_derivatives, @ignore_derivatives
 # tangents
-export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk
+export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk, AccumThunk
 
 include("compat.jl")
 include("debug_mode.jl")

--- a/src/accumulation.jl
+++ b/src/accumulation.jl
@@ -20,7 +20,7 @@ function add!!(x, t::InplaceableThunk)
             debug_add!(x, t)
         end
     else
-        x + t
+        x + unthunk(t)
     end
 end
 
@@ -28,7 +28,14 @@ add!!(x::AbstractArray, y::Thunk) = add!!(x, unthunk(y))
 
 function add!!(x::AbstractArray{<:Any,N}, y::AbstractArray{<:Any,N}) where {N}
     return if is_inplaceable_destination(x)
-        x .+= y
+        if !debug_mode()
+            x .+= y
+        else
+            z = x + y
+            # Now write junk into x, to test that nothing is relying on mutation, only using returned value:
+            x .*= NaN
+            z
+        end
     else
         x + y
     end

--- a/src/accumulation.jl
+++ b/src/accumulation.jl
@@ -26,6 +26,17 @@ end
 
 add!!(x::AbstractArray, y::Thunk) = add!!(x, unthunk(y))
 
+# add!!(x::AbstractArray, y::AccumThunk) = add!!(x, unthunk(y))  # not sure! This may be less efficient than fallback
+
+function add!!(x::AbstractArray, y::AccumThunk)
+    return if is_inplaceable_destination(x)
+        x .+= y
+    else
+        # We are free to mutate the other way...
+        add!!(y.value, x)
+    end
+end
+
 function add!!(x::AbstractArray{<:Any,N}, y::AbstractArray{<:Any,N}) where {N}
     return if is_inplaceable_destination(x)
         if !debug_mode()


### PR DESCRIPTION
As far as I know `InplaceableThunk` never does anything at present, since gradients are accumulated with `+`, and this un-thunks before adding.

This PR marks some arrays as safe to mutate, and then mutates them when adding another array, or an  `InplaceableThunk`. The only arrays it marks are ones produced by adding a thunk to something, as this is sure to be a new array. This is no help for an accumulation of 2 terms, but helps with the 3rd and after, and should make N terms O(1).

#539 explores a different rule, assuming any `@thunk` expands to something safe to mutate. That helps with the 2nd `Thunk`. Both could be done.

The marker it uses is a new AbstractThunk. This is nice because consumers of gradients must already know to call `unthunk` if they need an array.

But in fact there's a small zoo of functions which automatically un-thunk. I'm not sure these are a great idea, as using them without thinking means you are likely to un-thunk twice or N times by accident. And using them on purpose requires memorising what's in the zoo and what's not. This PR adds one more problem: If you were relying on `+` to un-thunk for you, it will now assume you are accumulating, mutate, and wrap the answer in another thunk. 

The other snag is that a rule like that for `z = x+y` whose pullback passes the same `dz` to both `dx` and `dy` risks wrong answers if it passes this new marker through. (Whereas earlier `Thunks` were safe.)  The [rrule in CR](https://github.com/JuliaDiff/ChainRules.jl/blob/e4029dfe651c6483ff92da1de3241c0c94bd3256/src/rulesets/Base/arraymath.jl#L415-L422) does not appear to have this problem, as `reshape` [automatically unthunks](https://github.com/JuliaDiff/ChainRulesCore.jl/blob/00e17d236e3c09063c5b27a52c550c841d591fd5/src/tangent_types/thunks.jl#L53) (and will be called N times). Rules for `.+` and maybe `.-` may need care... I believe CR's will simply fail [here](https://github.com/JuliaDiff/ChainRules.jl/blob/main/src/rulesets/Base/broadcast.jl#L319-L321) since `ndims(@thunk [1,2])` is an error. Perhaps no `rrule` should ever transmit a thunk unchanged, and this could be automated somewhere?

Maybe this isn't quite safe enough.

What was the plan for `InplaceableThunk`? Was anything written when it was designed?