### PR TITLE
real(z::AbstractZero)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.3"
+version = "1.15.4"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -108,8 +108,7 @@ for T in (:AbstractThunk, :Tangent, :Any)
     @eval LinearAlgebra.dot(::$T, ::ZeroTangent) = ZeroTangent()
 end
 
-Base.real(::ZeroTangent) = ZeroTangent()
-Base.imag(::ZeroTangent) = ZeroTangent()
+Base.real(z::AbstractZero) = z
 
 Base.complex(::ZeroTangent) = ZeroTangent()
 Base.complex(::ZeroTangent, ::ZeroTangent) = ZeroTangent()

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -109,6 +109,7 @@ for T in (:AbstractThunk, :Tangent, :Any)
 end
 
 Base.real(z::AbstractZero) = z
+Base.imag(z::AbstractZero) = z
 
 Base.complex(::ZeroTangent) = ZeroTangent()
 Base.complex(::ZeroTangent, ::ZeroTangent) = ZeroTangent()


### PR DESCRIPTION
This came up in https://github.com/JuliaDiff/Diffractor.jl/pull/88/files 

Not sure I understand what the logic of this file is, as to which functions accept what kind of zero. Nor what's gained by having (at least) two.

FAQ entry: https://juliadiff.org/ChainRulesCore.jl/stable/FAQ.html#faq_abstract_zero This seems to imply that you cannot tell from the type of the primal whether it will always only have ZeroTangent or NoTangent. It depends on how it is being used. Since the function producing it may not know how it will be used next, does that imply that all pullbacks must accept both equally?