### PR TITLE
remove unbound type parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.4"
+version = "1.15.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_types/tangent.jl
+++ b/src/tangent_types/tangent.jl
@@ -65,7 +65,7 @@ end
 function Base.:(==)(a::Tangent{P,T}, b::Tangent{P,T}) where {P,T}
     return backing(a) == backing(b)
 end
-function Base.:(==)(a::Tangent{P}, b::Tangent{P}) where {P,T}
+function Base.:(==)(a::Tangent{P}, b::Tangent{P}) where {P}
     all_fields = union(keys(backing(a)), keys(backing(b)))
     return all(getproperty(a, f) == getproperty(b, f) for f in all_fields)
 end
@@ -117,7 +117,7 @@ function Base.getindex(tangent::Tangent{P,T}, idx::Symbol) where {P,T<:NamedTupl
     hasfield(T, idx) || return ZeroTangent()
     return unthunk(getfield(backing(tangent), idx))
 end
-function Base.getindex(tangent::Tangent, idx) where {P,T<:AbstractDict}
+function Base.getindex(tangent::Tangent, idx)
     return unthunk(getindex(backing(tangent), idx))
 end
 
@@ -237,8 +237,8 @@ canonicalize(tangent::Tangent{<:Any,<:AbstractDict}) = tangent
 # Tangents of unspecified primal types (indicated by specifying exactly `Any`)
 # all combinations of type-params are specified here to avoid ambiguities
 canonicalize(tangent::Tangent{Any,<:NamedTuple{L}}) where {L} = tangent
-canonicalize(tangent::Tangent{Any,<:Tuple}) where {L} = tangent
-canonicalize(tangent::Tangent{Any,<:AbstractDict}) where {L} = tangent
+canonicalize(tangent::Tangent{Any,<:Tuple}) = tangent
+canonicalize(tangent::Tangent{Any,<:AbstractDict}) = tangent
 
 """
     _zeroed_backing(P)


### PR DESCRIPTION
I didn't check, but unbound type parameters often cause performance issues, so this isn't merely cosmetic.

FTR, there's a relevant function in Test in stdlib for checking this stuff:
https://docs.julialang.org/en/v1/stdlib/Test/#Test.detect_unbound_args