### PR TITLE
Fix some method ambiguities

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.15.5"
+version = "1.15.6"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -32,12 +32,10 @@ for T in (:ZeroTangent, :NoTangent)
     @eval LinearAlgebra.dot(::NotImplemented, ::$T) = $T()
     @eval LinearAlgebra.dot(::$T, ::NotImplemented) = $T()
 end
-# `NotImplemented` "wins" *, /, and dot for other types
+# `NotImplemented` "wins" *, and dot for other types
 for T in (:AbstractThunk, :Tangent, :Any)
     @eval Base.:*(x::NotImplemented, ::$T) = x
     @eval Base.:*(::$T, x::NotImplemented) = x
-    @eval Base.:/(x::NotImplemented, ::$T) = x
-    @eval Base.:/(::$T, x::NotImplemented) = x
     @eval LinearAlgebra.dot(x::NotImplemented, ::$T) = x
     @eval LinearAlgebra.dot(::$T, x::NotImplemented) = x
 end

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -32,7 +32,7 @@ for T in (:ZeroTangent, :NoTangent)
     @eval LinearAlgebra.dot(::NotImplemented, ::$T) = $T()
     @eval LinearAlgebra.dot(::$T, ::NotImplemented) = $T()
 end
-# `NotImplemented` "wins" *, and dot for other types
+# `NotImplemented` "wins" * and dot for other types
 for T in (:AbstractThunk, :Tangent, :Any)
     @eval Base.:*(x::NotImplemented, ::$T) = x
     @eval Base.:*(::$T, x::NotImplemented) = x

--- a/src/tangent_arithmetic.jl
+++ b/src/tangent_arithmetic.jl
@@ -32,10 +32,12 @@ for T in (:ZeroTangent, :NoTangent)
     @eval LinearAlgebra.dot(::NotImplemented, ::$T) = $T()
     @eval LinearAlgebra.dot(::$T, ::NotImplemented) = $T()
 end
-# `NotImplemented` "wins" * and dot for other types
+# `NotImplemented` "wins" *, /, and dot for other types
 for T in (:AbstractThunk, :Tangent, :Any)
     @eval Base.:*(x::NotImplemented, ::$T) = x
     @eval Base.:*(::$T, x::NotImplemented) = x
+    @eval Base.:/(x::NotImplemented, ::$T) = x
+    @eval Base.:/(::$T, x::NotImplemented) = x
     @eval LinearAlgebra.dot(x::NotImplemented, ::$T) = x
     @eval LinearAlgebra.dot(::$T, x::NotImplemented) = x
 end

--- a/src/tangent_types/notimplemented.jl
+++ b/src/tangent_types/notimplemented.jl
@@ -43,8 +43,10 @@ Base.:/(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))
 Base.:/(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
-# Fix method ambiguity error
+# Fix method ambiguity errors (#589)
 Base.:/(x::AbstractZero, ::NotImplemented) = x
+Base.:/(x::NotImplemented, ::AbstractThunk) = throw(NotImplementedException(x))
+Base.:/(::AbstractThunk, x::NotImplemented) = throw(NotImplementedException(x))
 
 Base.zero(x::NotImplemented) = throw(NotImplementedException(x))
 function Base.zero(::Type{<:NotImplemented})

--- a/src/tangent_types/notimplemented.jl
+++ b/src/tangent_types/notimplemented.jl
@@ -43,6 +43,9 @@ Base.:/(x::NotImplemented, ::Any) = throw(NotImplementedException(x))
 Base.:/(::Any, x::NotImplemented) = throw(NotImplementedException(x))
 Base.:/(x::NotImplemented, ::NotImplemented) = throw(NotImplementedException(x))
 
+# Fix method ambiguity error
+Base.:/(x::AbstractZero, ::NotImplemented) = x
+
 Base.zero(x::NotImplemented) = throw(NotImplementedException(x))
 function Base.zero(::Type{<:NotImplemented})
     return throw(

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -33,8 +33,13 @@ Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
 Base.:(-)(a::AbstractThunk) = -unthunk(a)
 Base.:(-)(a::AbstractThunk, b) = unthunk(a) - b
 Base.:(-)(a, b::AbstractThunk) = a - unthunk(b)
+Base.:(-)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) - unthunk(b)
 Base.:(/)(a::AbstractThunk, b) = unthunk(a) / b
 Base.:(/)(a, b::AbstractThunk) = a / unthunk(b)
+Base.:(/)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) / unthunk(b)
+
+# Fix method ambiguity issue
+Base.:/(a::AbstractZero, ::AbstractThunk) = a
 
 Base.real(a::AbstractThunk) = real(unthunk(a))
 Base.imag(a::AbstractThunk) = imag(unthunk(a))

--- a/test/tangent_types/notimplemented.jl
+++ b/test/tangent_types/notimplemented.jl
@@ -21,7 +21,7 @@
         @test ni + ni2 === ni
         @test ni2 + ni === ni2
 
-        # multiplication and dot product
+        # multiplication, division, and dot product
         @test -ni == ni
         for a in (true, x, thunk)
             @test ni * a === ni
@@ -32,6 +32,7 @@
         for a in (NoTangent(), ZeroTangent())
             @test ni * a === a
             @test a * ni === a
+            @test a / ni === a
             @test dot(ni, a) === a
             @test dot(a, ni) === a
         end
@@ -52,8 +53,10 @@
             @test_throws E a - ni
         end
         @test_throws E ni - ni2
-        @test_throws E ni / x
-        @test_throws E x / ni
+        for a in (true, x, thunk)
+            @test_throws E ni / a
+            @test_throws E a / ni
+        end
         @test_throws E ni / ni2
         @test_throws E zero(ni)
         @test_throws E zero(typeof(ni))

--- a/test/tangent_types/thunks.jl
+++ b/test/tangent_types/thunks.jl
@@ -101,8 +101,15 @@
         @test 1 == -@thunk(-1)
         @test 1 == @thunk(2) - 1
         @test 1 == 2 - @thunk(1)
+        @test 1 == @thunk(2) - @thunk(1)
         @test 1.0 == @thunk(1) / 1.0
         @test 1.0 == 1.0 / @thunk(1)
+        @test 1 == @thunk(1) / @thunk(1)
+
+        # check method ambiguities (#589)
+        for a in (ZeroTangent(), NoTangent())
+            @test a / @thunk(2) === a
+        end
 
         @test 1 == real(@thunk(1 + 1im))
         @test 1 == imag(@thunk(1 + 1im))


### PR DESCRIPTION
Does not fix https://github.com/JuliaDiff/ChainRulesCore.jl/issues/588 but reduces method ambiguities from

```julia
julia> Test.detect_ambiguities(ChainRulesCore)
14-element Vector{Tuple{Method, Method}}:
 (/(z::AbstractZero, ::Any) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/abstract_zero.jl:29, /(a, b::AbstractThunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:37)
 (/(a::AbstractThunk, b) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:36, /(a, b::AbstractThunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:37)
 ((::ChainRulesCore.var"#frule##kw")(kws, ::typeof(frule), ::RuleConfig, args...) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/rules.jl:77, (::ChainRulesCore.var"#frule##kw")(kwargs, frule::typeof(frule), ::Any, ::typeof(ignore_derivatives), f) in ChainRulesCore)
 (frule(::Any, ::typeof(ignore_derivatives), f) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/ignore_derivatives.jl:40, frule(::RuleConfig, args...) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/rules.jl:64)
 ((::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:129, (::ProjectTo{T})(dx::Tangent{<:T}) where T in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:143)
 (ger!(alpha, x::AbstractThunk, y, A) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:110, ger!(alpha, x, y::AbstractThunk, A) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:113)
 (LinearAlgebra.UniformScaling{T}(λ) where T<:Number in LinearAlgebra at /home/david/.julia/juliaup/julia-1.8.1+0.x64/share/julia/stdlib/v1.8/LinearAlgebra/src/uniformscaling.jl:40, (::Type{<:LinearAlgebra.UniformScaling})(z::AbstractZero) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/abstract_zero.jl:44)
 ((project::ProjectTo)(dx::InplaceableThunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:125, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:129)
 ((project::ProjectTo)(dx::Thunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:124, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:129)
 (/(z::AbstractZero, ::Any) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/abstract_zero.jl:29, /(::Any, x::ChainRulesCore.NotImplemented) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/notimplemented.jl:43)
 ((::ProjectTo{T})(dx::ChainRulesCore.NotImplemented) where T in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:121, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/projection.jl:129)
 (/(::Any, x::ChainRulesCore.NotImplemented) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/notimplemented.jl:43, /(a::AbstractThunk, b) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:36)
 (-(a::AbstractThunk, b) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:34, -(a, b::AbstractThunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:35)
 (/(x::ChainRulesCore.NotImplemented, ::Any) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/notimplemented.jl:42, /(a, b::AbstractThunk) in ChainRulesCore at /home/david/.julia/packages/ChainRulesCore/Z4Jry/src/tangent_types/thunks.jl:37)
```
to
```julia
julia> Test.detect_ambiguities(ChainRulesCore)
8-element Vector{Tuple{Method, Method}}:
 (LinearAlgebra.UniformScaling{T}(λ) where T<:Number in LinearAlgebra at /home/david/.julia/juliaup/julia-1.8.1+0.x64/share/julia/stdlib/v1.8/LinearAlgebra/src/uniformscaling.jl:40, (::Type{<:LinearAlgebra.UniformScaling})(z::AbstractZero) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/tangent_types/abstract_zero.jl:44)
 ((::ProjectTo{T})(dx::ChainRulesCore.NotImplemented) where T in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:121, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:129)
 ((project::ProjectTo)(dx::InplaceableThunk) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:125, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:129)
 ((project::ProjectTo)(dx::Thunk) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:124, (::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:129)
 ((::ChainRulesCore.var"#frule##kw")(kws, ::typeof(frule), ::RuleConfig, args...) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/rules.jl:77, (::ChainRulesCore.var"#frule##kw")(kwargs, frule::typeof(frule), ::Any, ::typeof(ignore_derivatives), f) in ChainRulesCore)
 ((::ProjectTo{NoTangent})(dx) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:129, (::ProjectTo{T})(dx::Tangent{<:T}) where T in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/projection.jl:143)
 (frule(::Any, ::typeof(ignore_derivatives), f) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/ignore_derivatives.jl:40, frule(::RuleConfig, args...) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/rules.jl:64)
 (ger!(alpha, x::AbstractThunk, y, A) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/tangent_types/thunks.jl:115, ger!(alpha, x, y::AbstractThunk, A) in ChainRulesCore at /home/david/.julia/dev/ChainRulesCore/src/tangent_types/thunks.jl:118)
```