### PR TITLE
use === instead of == to compare Symbols

### DIFF
--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -510,7 +510,7 @@ function _target_rewrite!(expr::Expr, no_rule)
     length(expr.args) === 0 && error("Malformed method expression. $expr")
     if expr.head === :call || expr.head === :where
         expr.args[1] = _target_rewrite!(expr.args[1], no_rule)
-    elseif expr.head == :(.) && expr.args[1] == :ChainRulesCore
+    elseif expr.head === :(.) && expr.args[1] === :ChainRulesCore
         expr = _target_rewrite!(expr.args[end], no_rule)
     else
         error("Malformed method expression. $(expr)")
@@ -519,13 +519,13 @@ function _target_rewrite!(expr::Expr, no_rule)
 end
 _target_rewrite!(qt::QuoteNode, no_rule) = _target_rewrite!(qt.value, no_rule)
 function _target_rewrite!(call_target::Symbol, no_rule)
-    return if call_target == :rrule && no_rule
+    return if call_target === :rrule && no_rule
         :($ChainRulesCore.no_rrule)
-    elseif call_target == :rrule && !no_rule
+    elseif call_target === :rrule && !no_rule
         :($ChainRulesCore.rrule)
-    elseif call_target == :frule && no_rule
+    elseif call_target === :frule && no_rule
         :($ChainRulesCore.no_frule)
-    elseif call_target == :frule && !no_rule
+    elseif call_target === :frule && !no_rule
         :($ChainRulesCore.frule)
     else
         error("Unexpected opt-out target. Expected frule or rrule, got: $call_target")
@@ -571,8 +571,8 @@ function _isvararg(expr::Expr)
     Meta.isexpr(expr, :...) && return true
     if Meta.isexpr(expr, :(::))
         constraint = last(expr.args)
-        constraint == :Vararg && return true
-        Meta.isexpr(constraint, :curly) && first(constraint.args) == :Vararg && return true
+        constraint === :Vararg && return true
+        Meta.isexpr(constraint, :curly) && first(constraint.args) === :Vararg && return true
     end
     return false
 end


### PR DESCRIPTION
I found invalidations from loading both ChainRulesCore.jl and SciMLBase.jl using the beta of Julia 1.9:
```julia
julia> using Pkg; Pkg.activate(temp=true); Pkg.add("SciMLBase"); Pkg.develop("ChainRulesCore")

julia> using SnoopCompileCore; invalidations = @snoopr(using ChainRulesCore, SciMLBase); using SnoopCompile

julia> trees = invalidation_trees(invalidations)
[...]
 inserting ==(retcode::SciMLBase.ReturnCode.T, s::Symbol) @ SciMLBase ~/.julia/packages/SciMLBase/QqtZA/src/retcodes.jl:348 invalidated:
   backedges: 1: superseding ==(x, y) @ Base Base.jl:127 with MethodInstance for ==(::Any, ::Symbol) (12 children)
```

I fixed invalidations by using `===` instead of `==` when comparing to a `Symbol`, which is also recommended in the docstring of `Symbol`:
```julia
help?> Symbol
search: Symbol
[...]
  Symbols are immutable and should be compared using ===. The implementation re-uses the same object for all
  Symbols with the same name, so comparison tends to be efficient (it can just compare pointers).
[...]
```
