### PR TITLE
Stop testing on 1.5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,11 +33,6 @@ jobs:
             arch: x86
           - os: windows-latest
             arch: x86
-        include:
-          # Add a 1.5 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: "1.5"
-            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This is forbidden by Project.toml: 

https://github.com/JuliaDiff/ChainRulesCore.jl/blob/ed9a0073ff83cb3b1f4619303e41f4dd5d8c4825/Project.toml#L16

Currently passes on CI, which must ignore that, e.g. https://github.com/JuliaDiff/ChainRulesCore.jl/actions/runs/4436617557/jobs/7785265494 