### PR TITLE
iszero for Tangents

### DIFF
--- a/src/tangent_types/tangent.jl
+++ b/src/tangent_types/tangent.jl
@@ -96,8 +96,8 @@ function Base.show(io::IO, tangent::Tangent{P}) where {P}
     end
 end
 
-Base.iszero(::Tangent{<:, NamedTuple{}}) = true
-Base.iszero(::Tangent{<:, Tuple{}}) = true
+Base.iszero(::Tangent{<:,NamedTuple{}}) = true
+Base.iszero(::Tangent{<:,Tuple{}}) = true
 Base.iszero(t::Tangent) = all(iszero, backing(t))
 
 Base.first(tangent::Tangent{P,T}) where {P,T<:Union{Tuple,NamedTuple}} = first(backing(canonicalize(tangent)))

--- a/src/tangent_types/tangent.jl
+++ b/src/tangent_types/tangent.jl
@@ -96,6 +96,10 @@ function Base.show(io::IO, tangent::Tangent{P}) where {P}
     end
 end
 
+Base.iszero(::Tangent{<:, NamedTuple{}}) = true
+Base.iszero(::Tangent{<:, Tuple{}}) = true
+Base.iszero(t::Tangent) = all(iszero, backing(t))
+
 Base.first(tangent::Tangent{P,T}) where {P,T<:Union{Tuple,NamedTuple}} = first(backing(canonicalize(tangent)))
 Base.last(tangent::Tangent{P,T}) where {P,T<:Union{Tuple,NamedTuple}} = last(backing(canonicalize(tangent)))
 

--- a/test/tangent_types/tangent.jl
+++ b/test/tangent_types/tangent.jl
@@ -376,7 +376,7 @@ end
         @test iszero(Tangent{Foo}(; y=0.0))
         @test iszero(Tangent{Foo}(; x=Tangent{Tuple{}}(), y=0.0))
 
-        @test !iszero(Tangent{Foo}(;y=3.0))
+        @test !iszero(Tangent{Foo}(; y=3.0))
     end
 
     @testset "show" begin

--- a/test/tangent_types/tangent.jl
+++ b/test/tangent_types/tangent.jl
@@ -369,6 +369,16 @@ end
         @test_throws MethodError Tangent{Foo}(; y=1.5, x=2.5) * @thunk [1 2; 3 4]
     end
 
+    @testset "iszero" begin
+        @test iszero(Tangent{Foo}())
+        @test iszero(Tangent{Tuple{}}())
+        @test iszero(Tangent{Foo}(; x=ZeroTangent()))
+        @test iszero(Tangent{Foo}(; y=0.0))
+        @test iszero(Tangent{Foo}(; x=Tangent{Tuple{}}(), y=0.0))
+
+        @test !iszero(Tangent{Foo}(;y=3.0))
+    end
+
     @testset "show" begin
         @test repr(Tangent{Foo}(; x=1)) == "Tangent{Foo}(x = 1,)"
         # check for exact regex match not occurence( `^...$`)


### PR DESCRIPTION
closes #619 
This makes for a nice canonical way to decide if something should be pulled back.
Since even complicated structures like:
```julia
julia> iszero([0.0, NoTangent(), [ZeroTangent(), Tangent{Foo}()]])
true
```
work right.

So this is better than just checking top-level type.
It is much cheaper to check if something is zero, even if it involved elementwise work than the vast majority of pullbacks so i think a case can be made that this should always been done by the AD. Or at least the AD should have special cases for things to treat as as always nonzero like dense numerical mastrixes `<:Array{<:Real}` (which are also things that rules support).

This should go well with https://github.com/FluxML/Zygote.jl/pull/1389