### PR TITLE
Let user specify Integer ->Float conversion type

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,6 +52,9 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-runtest@latest # Run for Int -> Float32
+        env:
+          INT2FLOAT: Float32
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test", "BenchmarkTools", "FiniteDifferences", "OffsetArrays", "StaticArrays"]
+test = ["Test", "BenchmarkTools", "FiniteDifferences", "OffsetArrays", "StaticArrays", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.16.0"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BenchmarkTools = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,11 @@ uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 version = "1.16.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -3,12 +3,9 @@ uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 version = "1.16.0"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 BenchmarkTools = "0.5"

--- a/src/ChainRulesCore.jl
+++ b/src/ChainRulesCore.jl
@@ -17,6 +17,7 @@ export ignore_derivatives, @ignore_derivatives
 # tangents
 export Tangent, NoTangent, InplaceableThunk, Thunk, ZeroTangent, AbstractZero, AbstractThunk
 
+include("preferences.jl")
 include("debug_mode.jl")
 
 include("tangent_types/abstract_tangent.jl")

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -3,7 +3,7 @@ using Preferences
 const int2float_type = @load_preference("int2float", "Float64")
 
 function set_int2float!(int2float_type::String)
-    if !(int2float_type in ("Float64", "Float32"))
+    if !(int2float_type in ("Float64", "Float32", "Float16"))
         throw(ArgumentError("Invalid int2float type: \"$(int2float_type)\""))
     end
 

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,0 +1,19 @@
+@static if VERSION >= v"1.6"
+    using Preferences
+end
+
+@static if VERSION >= v"1.6"
+    const int2float_type = @load_preference("int2float", "Float64")
+else
+    const int2float_type = "Float32"
+end
+
+function set_int2float!(int2float_type::String)
+    if !(int2float_type in ("Float64", "Float32"))
+        throw(ArgumentError("Invalid int2float type: \"$(int2float_type)\""))
+    end
+
+    # Set it in our runtime values, as well as saving it to disk
+    @set_preferences!("int2float" => int2float_type)
+    @info("New int2float type set; restart your Julia session for this change to take effect!")
+end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,12 +1,6 @@
-@static if VERSION >= v"1.6"
-    using Preferences
-end
+using Preferences
 
-@static if VERSION >= v"1.6"
-    const int2float_type = @load_preference("int2float", "Float64")
-else
-    const int2float_type = "Float32"
-end
+const int2float_type = @load_preference("int2float", "Float64")
 
 function set_int2float!(int2float_type::String)
     if !(int2float_type in ("Float64", "Float32"))

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -9,5 +9,7 @@ function set_int2float!(int2float_type::String)
 
     # Set it in our runtime values, as well as saving it to disk
     @set_preferences!("int2float" => int2float_type)
-    @info("New int2float type set; restart your Julia session for this change to take effect!")
+    @info(
+        "New int2float type set; restart your Julia session for this change to take effect!"
+    )
 end

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -160,12 +160,12 @@ ProjectTo(::Complex) = ProjectTo{Complex}()
 ProjectTo(::Number) = ProjectTo{Number}()
 
 function ProjectTo(x::Integer)
-    @static if int2float_type == "Float64"
-        return ProjectTo{Float64}()
+    @static if int2float_type == "Float16"
+        return ProjectTo{Float16}()
     elseif int2float_type == "Float32"
         return ProjectTo{Float32}()
-    else
-        return nothing
+    else # Float64
+        return ProjectTo{Float64}()
     end
 end
 

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -169,15 +169,7 @@ function ProjectTo(x::Integer)
     end
 end
 
-function ProjectTo(x::Complex{<:Integer})
-    @static if int2float_type == "Float16"
-        return ProjectTo(Float16(x))
-    elseif int2float_type == "Float32"
-        return ProjectTo(Float32(x))
-    else # Float64
-        return ProjectTo(Float64(x))
-    end
-end
+ProjectTo(x::Complex{<:Integer}) = ProjectTo(float(x))
 
 # Preserve low-precision floats as accidental promotion is a common performance bug
 for T in (Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -161,15 +161,23 @@ ProjectTo(::Number) = ProjectTo{Number}()
 
 function ProjectTo(x::Integer)
     @static if int2float_type == "Float16"
-        return ProjectTo{Float16}()
+        return ProjectTo(Float16(x))
     elseif int2float_type == "Float32"
-        return ProjectTo{Float32}()
+        return ProjectTo(Float32(x))
     else # Float64
-        return ProjectTo{Float64}()
+        return ProjectTo(Float64(x))
     end
 end
 
-ProjectTo(x::Complex{<:Integer}) = ProjectTo(float(x))
+function ProjectTo(x::Complex{<:Integer})
+    @static if int2float_type == "Float16"
+        return ProjectTo(Float16(x))
+    elseif int2float_type == "Float32"
+        return ProjectTo(Float32(x))
+    else # Float64
+        return ProjectTo(Float64(x))
+    end
+end
 
 # Preserve low-precision floats as accidental promotion is a common performance bug
 for T in (Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64)

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -394,7 +394,6 @@ function (project::ProjectTo{<:Tangent{<:Tuple}})(dx::AbstractArray)
     end
 end
 
-
 #####
 ##### `LinearAlgebra`
 #####

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -159,7 +159,16 @@ ProjectTo(::Real) = ProjectTo{Real}()
 ProjectTo(::Complex) = ProjectTo{Complex}()
 ProjectTo(::Number) = ProjectTo{Number}()
 
-ProjectTo(x::Integer) = ProjectTo(float(x))
+function ProjectTo(x::Integer)
+    @static if int2float_type == "Float64"
+        return ProjectTo{Float64}()
+    elseif int2float_type == "Float32"
+        return ProjectTo{Float32}()
+    else
+        return nothing
+    end
+end
+
 ProjectTo(x::Complex{<:Integer}) = ProjectTo(float(x))
 
 # Preserve low-precision floats as accidental promotion is a common performance bug

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -69,7 +69,7 @@ struct NoSuperType end
         
         @test pvec3(1:3) == 1.0:3.0  # would prefer ===, map(Float64, dx) would do that, not important
         @test pvec3([1, 2, 3 + 4im]) == 1:3
-        @test eltype(pvec3([1, 2, 3.0f0])) === Float32
+        @test eltype(pvec3([1, 2, 3.0f0])) === typeof(int2float(1))
 
         # reshape
         @test pvec3(reshape([1, 2, 3], 3, 1)) isa Vector

--- a/test/projection.jl
+++ b/test/projection.jl
@@ -35,6 +35,8 @@ struct NoSuperType end
         @test ProjectTo(1.0f0 + 2im)(3) === 3.0f0 + 0im
         @test ProjectTo(big(1.0))(2) === 2
         @test ProjectTo(1.0)(2) === 2.0
+        @test ProjectTo(1.0f0)(2) === 2.0f0
+        @test ProjectTo(1)(2.0f0) === 2.0
 
         # Tangents
         ProjectTo(1.0f0 + 2im)(Tangent{ComplexF64}(; re=1, im=NoTangent())) ===
@@ -62,7 +64,7 @@ struct NoSuperType end
         @test pvec3(1.0:3.0) === 1.0:3.0
         @test pvec3(1:3) == 1.0:3.0  # would prefer ===, map(Float64, dx) would do that, not important
         @test pvec3([1, 2, 3 + 4im]) == 1:3
-        @test eltype(pvec3([1, 2, 3.0f0])) === Float64
+        @test eltype(pvec3([1, 2, 3.0f0])) === Float32
 
         # reshape
         @test pvec3(reshape([1, 2, 3], 3, 1)) isa Vector
@@ -293,7 +295,7 @@ struct NoSuperType end
         pdiag = ProjectTo(Diagonal(1:3))
         @test pdiag(reshape(1:9, 3, 3)) == Diagonal([1, 5, 9])
         @test pdiag(pdiag(reshape(1:9, 3, 3))) == pdiag(reshape(1:9, 3, 3))
-        @test pdiag(rand(ComplexF32, 3, 3)) isa Diagonal{Float64}
+        @test pdiag(rand(ComplexF32, 3, 3)) isa Diagonal{Float32}
         @test pdiag(Diagonal(1.0:3.0)) === Diagonal(1.0:3.0)
         @test ProjectTo(Diagonal(randn(3) .> 0))(randn(3, 3)) == NoTangent()
         @test ProjectTo(Diagonal(randn(3) .> 0))(Diagonal(rand(3))) == NoTangent()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,12 @@ using Preferences
 using UUIDs
 
 # Test Float32 value for int2float
-env_int2float = ENV["INT2FLOAT"]
-if "INT2FLOAT" ∈ keys(ENV) && env_int2float ∈ ["Float32", "Float16"]
+
+if "INT2FLOAT" ∈ keys(ENV)
+    env_int2float = ENV["INT2FLOAT"]
+end
+
+if env_int2float ∈ ["Float32", "Float16"]
     chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
     set_preferences!(chainrulescore_uuid, "int2float" => env_int2float)
     println("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using StaticArrays
 using SparseArrays
 using Test
 
+int2float(x) = ProjectTo(1)(x)
+
 @testset "ChainRulesCore" begin
     @testset "differentials" begin
         include("tangent_types/abstract_zero.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,12 @@ using Preferences
 using UUIDs
 
 # Test Float32 value for int2float
-if "INT2FLOAT" ∈ keys(ENV) && ENV["INT2FLOAT"] == "Float32"
+env_int2float = ENV["INT2FLOAT"]
+if "INT2FLOAT" ∈ keys(ENV) && env_int2float ∈ ["Float32", "Float16"]
     chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
-    set_preferences!(chainrulescore_uuid, "int2float" => "Float32")
+    set_preferences!(chainrulescore_uuid, "int2float" => env_int2float)
     println("")
-    println("Running ChainRulesCore tests with Float32")
+    println("Running ChainRulesCore tests with $env_int2float")
 end
 
 using ChainRulesCore

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,13 @@
 using Base.Broadcast: broadcastable
 using BenchmarkTools
+using Preferences
+
+# Test Float32 value for int2float
+if "INT2FLOAT" ∈ keys(ENV) && ENV["INT2FLOAT"] == "Float32"
+    chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
+    set_preferences!(chainrulescore_uuid, "int2float" => "Float32")
+end
+
 using ChainRulesCore
 using LinearAlgebra
 using LinearAlgebra.BLAS: ger!, gemv!, gemv, scal!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ using UUIDs
 if "INT2FLOAT" ∈ keys(ENV) && ENV["INT2FLOAT"] == "Float32"
     chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
     set_preferences!(chainrulescore_uuid, "int2float" => "Float32")
+    println("")
+    println("Running ChainRulesCore tests with Float32")
 end
 
 using ChainRulesCore

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Broadcast: broadcastable
 using BenchmarkTools
 using Preferences
+using UUIDs
 
 # Test Float32 value for int2float
 if "INT2FLOAT" ∈ keys(ENV) && ENV["INT2FLOAT"] == "Float32"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,13 +7,13 @@ using UUIDs
 
 if "INT2FLOAT" ∈ keys(ENV)
     env_int2float = ENV["INT2FLOAT"]
-end
 
-if env_int2float ∈ ["Float32", "Float16"]
-    chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
-    set_preferences!(chainrulescore_uuid, "int2float" => env_int2float)
-    println("")
-    println("Running ChainRulesCore tests with $env_int2float")
+    if env_int2float ∈ ["Float32", "Float16"]
+        chainrulescore_uuid = UUID("d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4")
+        set_preferences!(chainrulescore_uuid, "int2float" => env_int2float)
+        println("")
+        println("Running ChainRulesCore tests with $env_int2float")
+    end
 end
 
 using ChainRulesCore

--- a/test/tangent_types/notimplemented.jl
+++ b/test/tangent_types/notimplemented.jl
@@ -104,7 +104,7 @@
         f̄, x̄1, x̄2 = pb(3.1)
         @test f̄ == NoTangent()
         @test x̄1 isa ChainRulesCore.NotImplemented
-        @test x̄2 == 3.1
+        @test x̄2 == int2float(3.1)
 
         notimplemented2(x, y) = (x + y, x - y)
         @scalar_rule notimplemented2(x, y) (@not_implemented("notimplemented2"), 1) (1, -1)
@@ -119,6 +119,6 @@
         f̄, x̄1, x̄2 = pb((3.1, 4.5))
         @test f̄ == NoTangent()
         @test x̄1 isa ChainRulesCore.NotImplemented
-        @test x̄2 == -1.4
+        @test x̄2 == int2float(-1.4)
     end
 end


### PR DESCRIPTION
Based on these related issues: https://github.com/FluxML/Flux.jl/issues/2305, https://github.com/FluxML/Zygote.jl/issues/1445, https://github.com/JuliaGPU/GPUArrays.jl/issues/484

it seems like it might be useful to have a bit more control over whether `Int` projections are mapped to `Float64` or another `AbstractFloat` subtype. While this might be possible via overloading, it would be nice to know that one hasn't broken any `ChanRulesCore.jl` functionality by overloading the method. Especially for working with GPUs, greedy type conversion to `Float64` seems to be problematic.

This PR introduces a local user preference `int2float` via which a `Float` type can be specified. I have also adjusted the tests so that they can be run with different preference settings.

The problem which this PR solves, in a nutshell:

```julia
using ChainRulesCore

# Second test fails
ProjectTo(1.0f0)(2) === 2.0f0
ProjectTo(1)(2.0f0) === 2.0f0

# Both tests pass (after restart)
ChainRulesCore.set_int2float!("Float32")
ProjectTo(1.0f0)(2) === 2.0f0
ProjectTo(1)(2.0f0) === 2.0f0
```

**Disclaimer** I'm new to this package and imagine that this may be the wrong way to fix the problem, so please don't hesitate to close this PR if I've missed something.