### PR TITLE
Define getproperty on AbstractZeroTangents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.16.0"
+version = "1.17.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -35,6 +35,8 @@ Base.convert(::Type{T}, x::AbstractZero) where {T<:Number} = zero(T)
 (::Type{Complex})(x::Real, y::AbstractZero) = Complex(x, false)
 
 Base.getindex(z::AbstractZero, args...) = z
+Base.getproperty(z::AbstractZero, name::Symbol) = z
+
 
 Base.view(z::AbstractZero, ind...) = z
 Base.sum(z::AbstractZero; dims=:) = z

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -86,6 +86,8 @@
         @test z[1:3] === z
         @test z[1, 2] === z
         @test getindex(z) === z
+
+        @test z.foo === z
         
         @test first(z) === z
         @test last(z) === z
@@ -134,6 +136,8 @@
         @test dne[1:3] === dne
         @test dne[1, 2] === dne
         @test getindex(dne) === dne
+        
+        @test dne.foo === dne
     end
 
     @testset "ambiguities" begin

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -136,7 +136,6 @@
         @test dne[1:3] === dne
         @test dne[1, 2] === dne
         @test getindex(dne) === dne
-        
         @test dne.foo === dne
     end
 


### PR DESCRIPTION
This is for the same reason `getindex` is defined.
Often you want to be able to treat a `ZeroTangent` as though it were a structural tangent.
So you want it to have the same fields as the primal just with them all zero