### PR TITLE
Add illustration of `∂self` in the maths/propagators section

### DIFF
--- a/docs/src/maths/propagators.md
+++ b/docs/src/maths/propagators.md
@@ -191,7 +191,7 @@ end
 function ChainRulesCore.rrule(m::Multiplier, y)
     product = m(y)
     function pullback(Δproduct) 
-        ∂self = Tangent{typeof(m)}(; x = Δproduct * y')
+        ∂self = Tangent{Multiplier}(; x = Δproduct * y')
         ∂y = m.x' * Δproduct
         return ∂self, ∂y
     end 

--- a/docs/src/maths/propagators.md
+++ b/docs/src/maths/propagators.md
@@ -191,9 +191,10 @@ end
 function ChainRulesCore.rrule(m::Multiplier, y)
     product = m(y)
     function pullback(Δproduct) 
-	    ∂self = Tangent{typeof(m)}(; x = Δproduct * y')
-	    ∂y = m.x' * Δproduct
-	    return ∂self, ∂y
+        ∂self = Tangent{typeof(m)}(; x = Δproduct * y')
+        ∂y = m.x' * Δproduct
+        return ∂self, ∂y
+    end 
     return product, pullback
 end
 ```

--- a/docs/src/maths/propagators.md
+++ b/docs/src/maths/propagators.md
@@ -179,6 +179,24 @@ So every `pushforward` takes in an extra argument, which is ignored unless the o
 It is common to write `function foo_pushforward(_, Δargs...)` in the case when `foo` does not have fields.
 Similarly every `pullback` returns an extra `∂self`, which for things without fields is `NoTangent()`, indicating there are no fields within the function itself.
 
+Here's an example showing how to define `∂self` in an `rrule` when the primal function has
+internal fields (implicit arguments):
+
+```julia
+struct Multiplier{T}
+    x::T
+end
+(m::Multiplier)(y) = m.x * y
+
+function ChainRulesCore.rrule(m::Multiplier, y)
+    product = m(y)
+    function pullback(Δproduct) 
+	    ∂self = Tangent{typeof(m)}(; x = Δproduct * y')
+	    ∂y = m.x' * Δproduct
+	    return ∂self, ∂y
+    return product, pullback
+end
+```
 
 ### Pushforward / Pullback summary
 


### PR DESCRIPTION
In response to a suggestion at [this](https://discourse.julialang.org/t/implementing-derivative-in-chainrules-for-function-with-internal-fields/66844/6?u=ablaom) Julia discourse thread.

Actually, there is an existing example in the docs, the "Pedagogical Example".  I expect it's still worth having another, simpler example, in the more specific context addressed here. At least, this would have helped me. 