### PR TITLE
tangent_arithmetic: add `norm` for `NoTangent`, `ZeroTangent` and `NotImplemented`

### DIFF
--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -23,6 +23,8 @@ Base.last(x::AbstractZero) = x
 Base.Broadcast.broadcastable(x::AbstractZero) = Ref(x)
 Base.Broadcast.broadcasted(::Type{T}) where {T<:AbstractZero} = T()
 
+LinearAlgebra.norm(::AbstractZero) = 0
+
 # Linear operators
 Base.adjoint(z::AbstractZero) = z
 Base.transpose(z::AbstractZero) = z

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -120,6 +120,9 @@
         @test dot(ZeroTangent(), dne) == ZeroTangent()
         @test dot(dne, ZeroTangent()) == ZeroTangent()
 
+        @test norm(ZeroTangent()) == 0
+        @test norm(ZeroTangent(), 0.4) == 0
+
         for x in dne
             @test x === dne
         end

--- a/test/tangent_types/tangent.jl
+++ b/test/tangent_types/tangent.jl
@@ -329,11 +329,15 @@ end
         @test c * NoTangent() == NoTangent()
         @test dot(NoTangent(), c) == NoTangent()
         @test dot(c, NoTangent()) == NoTangent()
+        @test norm(Tangent{Foo}(; y=c.y, x=NoTangent())) == c.y
+        @test norm(NoTangent(), Inf) == 0
 
         @test ZeroTangent() * c == ZeroTangent()
         @test c * ZeroTangent() == ZeroTangent()
         @test dot(ZeroTangent(), c) == ZeroTangent()
         @test dot(c, ZeroTangent()) == ZeroTangent()
+        @test norm(ZeroTangent()) == 0
+        @test norm(ZeroTangent(), 0.4) == 0
 
         @test true * c === c
         @test c * true === c


### PR DESCRIPTION
Fixes #639.

`norm` now returns 0 for the named tangents.

I noticed, however, that the similar implementations of `dot(tangent, tangent)` or `tangent*tangent` return `ZeroTangent()` instead. To my understanding, returning a tangent in those cases is never correct (probably `tangent*tangent` should not be defined at all). Probably that’s a different issue, but here it is the rationale for sticking with 0 for `norm`.

Please let me know if there is anything I can do to improve this!