### PR TITLE
Delete StaticArrays Projection tests

### DIFF
--- a/test/projection.jl
+++ b/test/projection.jl
@@ -379,27 +379,6 @@ struct NoSuperType end
     end
 
     #####
-    ##### `StaticArrays`
-    #####
-
-        @testset "StaticArrays" begin
-            # There is no code for this, but when argument isa StaticArray, axes(x) === axes(dx)
-            # implies a check, and reshape will wrap a Vector into a static SizedVector:
-            pstat = ProjectTo(SA[1, 2, 3])
-            @test axes(pstat(rand(3))) === (SOneTo(3),)
-
-            # This recurses into structured arrays:
-            pst = ProjectTo(transpose(SA[1, 2, 3]))
-            @test axes(pst(rand(1,3))) === (SOneTo(1), SOneTo(3))
-            @test pst(rand(1,3)) isa Transpose
-
-            # When the argument is an ordinary Array, static gradients are allowed to pass,
-            # like FillArrays. Collecting to an Array would cost a copy.
-            pvec3 = ProjectTo([1, 2, 3])
-            @test pvec3(SA[1, 2, 3]) isa StaticArray
-        end
-
-    #####
     ##### `ChainRulesCore`
     #####
 


### PR DESCRIPTION
This is the companion to https://github.com/JuliaArrays/StaticArrays.jl/pull/1228
see that PR for full details.
the tl;dr is:
These tests were breaking because of a change made in StaticArrays to how projections work (good that's their job) away from the default behavour which is implemented in this package.
It thus no longer makes sense to test StaticArrays still has the default behavour in this package.
Since we can't influence that.

Possibly we should have some other type we use to test this?

Note: this is not quiet enough to drop StaticArrays as a dependency entirely, as it is still used to test inplace accumulation into an immuatable array.