### PR TITLE
Fix ambig with configured frule created by non_differentiable rule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.19.0"
+version = "1.19.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -403,13 +403,13 @@ function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
         function (::Core.kwftype(typeof(ChainRulesCore.frule)))(
             @nospecialize($kwargs::Any),
             frule::typeof(ChainRulesCore.frule),
-            @nospecialize(::Any),
+            @nospecialize(::RuleConfig),
             $(map(esc, primal_sig_parts)...),
         )
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), NoTangent())
         end
         function ChainRulesCore.frule(
-            @nospecialize(::Any), $(map(esc, primal_sig_parts)...)
+            @nospecialize(::RuleConfig), $(map(esc, primal_sig_parts)...)
         )
             $(__source__)
             # Julia functions always only have 1 output, so return a single NoTangent()

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -403,13 +403,13 @@ function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
         function (::Core.kwftype(typeof(ChainRulesCore.frule)))(
             @nospecialize($kwargs::Any),
             frule::typeof(ChainRulesCore.frule),
-            @nospecialize(::RuleConfig),
+            ::$RuleConfig,
             $(map(esc, primal_sig_parts)...),
         )
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), NoTangent())
         end
         function ChainRulesCore.frule(
-            @nospecialize(::RuleConfig), $(map(esc, primal_sig_parts)...)
+            ::$RuleConfig, $(map(esc, primal_sig_parts)...)
         )
             $(__source__)
             # Julia functions always only have 1 output, so return a single NoTangent()

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -403,13 +403,13 @@ function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
         function (::Core.kwftype(typeof(ChainRulesCore.frule)))(
             @nospecialize($kwargs::Any),
             frule::typeof(ChainRulesCore.frule),
-            ::Tuple,
+            @nospecialize(::Tuple),
             $(map(esc, primal_sig_parts)...),
         )
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), NoTangent())
         end
         function ChainRulesCore.frule(
-            ::Tuple, $(map(esc, primal_sig_parts)...)
+            @nospecialize(::Tuple), $(map(esc, primal_sig_parts)...)
         )
             $(__source__)
             # Julia functions always only have 1 output, so return a single NoTangent()

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -403,13 +403,13 @@ function _nondiff_frule_expr(__source__, primal_sig_parts, primal_invoke)
         function (::Core.kwftype(typeof(ChainRulesCore.frule)))(
             @nospecialize($kwargs::Any),
             frule::typeof(ChainRulesCore.frule),
-            ::$RuleConfig,
+            ::Tuple,
             $(map(esc, primal_sig_parts)...),
         )
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), NoTangent())
         end
         function ChainRulesCore.frule(
-            ::$RuleConfig, $(map(esc, primal_sig_parts)...)
+            ::Tuple, $(map(esc, primal_sig_parts)...)
         )
             $(__source__)
             # Julia functions always only have 1 output, so return a single NoTangent()

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -220,14 +220,14 @@ end
 
             foo_ndc1(x) = string(x)
             @non_differentiable foo_ndc1(x)
-            @test frule(AllConfig(), foo_ndc1, 2.0) == (string(2.0), NoTangent())
+            @test frule(AllConfig(), (NoTangent(), NoTangent()), foo_ndc1, 2.0) == (string(2.0), NoTangent())
             r1, pb1 = rrule(AllConfig(), foo_ndc1, 2.0)
             @test r1 == string(2.0)
             @test pb1(NoTangent()) == (NoTangent(), NoTangent())
 
             foo_ndc2(x; y=0) = string(x + y)
             @non_differentiable foo_ndc2(x)
-            @test frule(AllConfig(), foo_ndc2, 2.0; y=4.0) == (string(6.0), NoTangent())
+            @test frule(AllConfig(), (NoTangent(), NoTangent()), foo_ndc2, 2.0; y=4.0) == (string(6.0), NoTangent())
             r2, pb2 = rrule(AllConfig(), foo_ndc2, 2.0; y=4.0)
             @test r2 == string(6.0)
             @test pb2(NoTangent()) == (NoTangent(), NoTangent())

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -225,7 +225,7 @@ end
             @test r1 == string(2.0)
             @test pb1(NoTangent()) == (NoTangent(), NoTangent())
 
-            foo_ndc2(x; y=0) = string(x+y)
+            foo_ndc2(x; y=0) = string(x + y)
             @non_differentiable foo_ndc2(x)
             @test frule(AllConfig(), foo_ndc2, 2.0; y=4.0) == (string(6.0), NoTangent())
             r2, pb2 = rrule(AllConfig(), foo_ndc2, 2.0; y=4.0)

--- a/test/rule_definition_tools.jl
+++ b/test/rule_definition_tools.jl
@@ -215,6 +215,24 @@ end
             @test pullback(4.5) == (NoTangent(), NoTangent(), NoTangent())
         end
 
+        @testset "interactions with configs" begin
+            struct AllConfig <: RuleConfig{Union{HasForwardsMode,NoReverseMode}} end
+
+            foo_ndc1(x) = string(x)
+            @non_differentiable foo_ndc1(x)
+            @test frule(AllConfig(), foo_ndc1, 2.0) == (string(2.0), NoTangent())
+            r1, pb1 = rrule(AllConfig(), foo_ndc1, 2.0)
+            @test r1 == string(2.0)
+            @test pb1(NoTangent()) == (NoTangent(), NoTangent())
+
+            foo_ndc2(x; y=0) = string(x+y)
+            @non_differentiable foo_ndc2(x)
+            @test frule(AllConfig(), foo_ndc2, 2.0; y=4.0) == (string(6.0), NoTangent())
+            r2, pb2 = rrule(AllConfig(), foo_ndc2, 2.0; y=4.0)
+            @test r2 == string(6.0)
+            @test pb2(NoTangent()) == (NoTangent(), NoTangent())
+        end
+
         @testset "Not supported (Yet)" begin
             # Where clauses are not supported.
             @test_macro_throws(


### PR DESCRIPTION
I am surprised we didn't run into this earlier.
I guess because noone has been using forward mode that seriously.
(in particular right now Diffractor doesn't support kwargs right: https://github.com/JuliaDiff/Diffractor.jl/issues/244)

Or maybe something changed in 1.10 (since https://github.com/JuliaDiff/ChainRules.jl/issues/765 also showed up)


Fixes https://github.com/SciML/Surrogates.jl/pull/462#issuecomment-1879935787
@ArnoStrouwen  can you confirm this fixes your problem, and if so approve this PR?
