### PR TITLE
Restrict kwarg type in code generated by @non_differentiable macro

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.20.0"
+version = "1.20.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/rule_definition_tools.jl
+++ b/src/rule_definition_tools.jl
@@ -445,7 +445,7 @@ function _nondiff_rrule_expr(__source__, primal_sig_parts, primal_invoke)
     return @strip_linenos quote
         # Manually defined kw version to save compiler work. See explanation in rules.jl
         function (::Core.kwftype(typeof(rrule)))(
-            $(esc(kwargs))::Any, ::typeof(rrule), $(esc_primal_sig_parts...)
+            $(esc(kwargs))::NamedTuple, ::typeof(rrule), $(esc_primal_sig_parts...)
         )
             return ($(esc(_with_kwargs_expr(primal_invoke, kwargs))), $pullback_expr)
         end


### PR DESCRIPTION
Fixes all the method ambiguities reported in ChainRules CI for julia 1.10
```julia
julia> filter(Test.detect_ambiguities(ChainRules, ChainRulesCore)) do t
   (t[1].name in [:rrule, Symbol("rrule##kw")])
end
Tuple{Method, Method}[]

```
closes https://github.com/JuliaDiff/ChainRules.jl/issues/777