### PR TITLE
add scaling division

### DIFF
--- a/src/tangent_types/abstract_tangent.jl
+++ b/src/tangent_types/abstract_tangent.jl
@@ -38,3 +38,6 @@ abstract type AbstractTangent end
 Base.:+(x::AbstractTangent) = x
 
 @inline Base.conj(x::AbstractTangent) = x
+
+Base.:/(x::AbstractTangent, y) = x * inv(y)
+Base.:\(x, y::AbstractTangent) = inv(x) * y

--- a/test/tangent_types/structural_tangent.jl
+++ b/test/tangent_types/structural_tangent.jl
@@ -396,6 +396,19 @@ end
             @test_throws MethodError Tangent{Foo}(; y=1.5, x=2.5) * @thunk [1 2; 3 4]
         end
 
+        @testset "scaling division" begin
+            a = Tangent{Foo}(; x=2.0, y=-2.0)
+            @test a / 2.0 == Tangent{Foo}(; x=1.0, y=-1.0) == 2.0 \ a
+            @test (
+                Tangent{Tuple{Float64,Float64}}(2.0, 4.0) / 2.0 ==
+                Tangent{Tuple{Float64,Float64}}(1.0, 2.0) ==
+                2.0 \ Tangent{Tuple{Float64,Float64}}(2.0, 4.0)
+            )
+
+
+        end
+
+
         @testset "iszero" begin
             @test iszero(Tangent{Foo}())
             @test iszero(Tangent{Tuple{}}())

--- a/test/tangent_types/structural_tangent.jl
+++ b/test/tangent_types/structural_tangent.jl
@@ -404,10 +404,7 @@ end
                 Tangent{Tuple{Float64,Float64}}(1.0, 2.0) ==
                 2.0 \ Tangent{Tuple{Float64,Float64}}(2.0, 4.0)
             )
-
-
         end
-
 
         @testset "iszero" begin
             @test iszero(Tangent{Foo}())


### PR DESCRIPTION
Basically #660 
though I implemented it on AbstractTangent.
Subtraction should be implemented the same.

We already have special cases for this on AbstructThunks, ZeroTangent and NotImplemented.
Potentially the AbstractThunk one could be removed. I don't think the ZeroTangent one could since strong zero