### PR TITLE
Bools have no tangent

### DIFF
--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -111,6 +111,7 @@ In general, it is more likely to produce a structural tangent.
 function zero_tangent end
 
 zero_tangent(x::Number) = zero(x)
+zero_tangent(x::Bool) = NoTangent()
 
 function zero_tangent(x::MutableTangent{P}) where {P}
     zb = backing(zero_tangent(backing(x)))
@@ -178,6 +179,8 @@ end
 
 # Sad heauristic methods we need because of unassigned values
 guess_zero_tangent_type(::Type{T}) where {T<:Number} = T
+guess_zero_tangent_type(::Type{Bool}) = NoTangent()
+
 guess_zero_tangent_type(::Type{T}) where {T<:Integer} = typeof(float(zero(T)))
 function guess_zero_tangent_type(::Type{<:Array{T,N}}) where {T,N}
     return Array{guess_zero_tangent_type(T),N}

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -165,6 +165,8 @@ end
     @testset "basics" begin
         @test zero_tangent(1) === 0
         @test zero_tangent(1.0) === 0.0
+        @test zero_tangent(true) === NoTangent()
+
         mutable struct MutDemo
             x::Float64
         end


### PR DESCRIPTION
Doing this improves type stability of Diffractor's forwards mode since if you have code that is like
```julia
y_smallest = if x>y
    y<z
else 
   false
end
```
then the first branch would get a tangent of `NoTangent()` due to the fact that we have `@non_differentiable Base.:>(::Any, ::Any)`.
But the second would (without this PR)  get a tangent of `false`.



I am tempted to make this Integers.
But seemed starting conservative with Bool might be better

@willtebbutt  you have thought about this a lot, what do you think?


