### PR TITLE
Disable thunks for 2nd order AD

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.25.0"
+version = "1.25.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -1,3 +1,4 @@
+# Disable thunks for 2nd order AD.
 _usethunks() = true
 rrule(::typeof(_usethunks)) = false, (NoTangent(),)
 

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -1,6 +1,6 @@
 # Disable thunks for 2nd order AD.
 _usethunks() = true
-rrule(::typeof(_usethunks)) = false, (NoTangent(),)
+rrule(::typeof(_usethunks)) = false, Returns((NoTangent(),))
 
 abstract type AbstractThunk <: AbstractTangent end
 
@@ -146,9 +146,9 @@ macro thunk(body)
     # so we get useful stack traces if it errors.
     func = Expr(:->, Expr(:tuple), Expr(:block, __source__, body))
     return quote
-        $(esc(_usethunks))() ?
+        _usethunks() ?
             Thunk($(esc(func))) :
-            $(esc(func))()
+            $(esc(body))
     end
 end
 

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -1,4 +1,5 @@
-const UTILIZE_THUNKS = Ref{Function}(() -> true)
+_usethunks() = true
+rrule(::typeof(_usethunks)) = false, (NoTangent(),)
 
 abstract type AbstractThunk <: AbstractTangent end
 
@@ -144,7 +145,7 @@ macro thunk(body)
     # so we get useful stack traces if it errors.
     func = Expr(:->, Expr(:tuple), Expr(:block, __source__, body))
     return quote
-        $(esc(UTILIZE_THUNKS))[]() ?
+        $(esc(_usethunks))() ?
             Thunk($(esc(func))) :
             $(esc(func))()
     end
@@ -241,7 +242,7 @@ struct InplaceableThunk{T<:Thunk,F} <: AbstractThunk
     val::T
 
     function InplaceableThunk(add!::F, val::T) where {F, T}
-        UTILIZE_THUNKS[]() ?
+        _usethunks() ?
             new{T, F}(add!, val) :
             val
     end

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -1,5 +1,4 @@
 const UTILIZE_THUNKS = Ref{Function}(() -> true)
-@noinline utilize_thunks() = UTILIZE_THUNKS[]()
 
 abstract type AbstractThunk <: AbstractTangent end
 
@@ -145,7 +144,7 @@ macro thunk(body)
     # so we get useful stack traces if it errors.
     func = Expr(:->, Expr(:tuple), Expr(:block, __source__, body))
     return quote
-        $(esc(utilize_thunks))() ?
+        $(esc(UTILIZE_THUNKS))[]() ?
             Thunk($(esc(func))) :
             $(esc(func))()
     end
@@ -242,7 +241,7 @@ struct InplaceableThunk{T<:Thunk,F} <: AbstractThunk
     val::T
 
     function InplaceableThunk(add!::F, val::T) where {F, T}
-        utilize_thunks() ?
+        UTILIZE_THUNKS[]() ?
             new{T, F}(add!, val) :
             val
     end


### PR DESCRIPTION
Needed for lazy Zygote:
https://github.com/FluxML/Zygote.jl/pull/966

Also bumped patch version so that we can tag a release afterwards.