### PR TITLE
fix: Allow arbitrary reshape in projection if array is zero sized

### DIFF
--- a/src/projection.jl
+++ b/src/projection.jl
@@ -224,9 +224,11 @@ function (project::ProjectTo{AbstractArray})(dx::AbstractArray{S,M}) where {S,M}
     dy = if axes(dx) === project.axes
         dx
     else
-        for d in 1:max(M, length(project.axes))
-            if size(dx, d) != length(get(project.axes, d, 1))
-                throw(_projection_mismatch(project.axes, size(dx)))
+        if !isempty(dx)
+            for d in 1:max(M, length(project.axes))
+                if size(dx, d) != length(get(project.axes, d, 1))
+                    throw(_projection_mismatch(project.axes, size(dx)))
+                end
             end
         end
         reshape(dx, project.axes)


### PR DESCRIPTION
This fixes a bug where during backpropagation the size of an array e.g. `(1, 1, 0)` does not match the size of the gradient e.g. `(4, 1, 0)`. The error only happens for zero-sized arrays.

See an example here: https://github.com/JuliaGraphs/GraphNeuralNetworks.jl/pull/638