### PR TITLE
Drop support for `Base.tail()`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChainRulesCore"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.26.1"
+version = "2.0.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -7,7 +7,7 @@ Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
-ChainRulesCore = "1"
+ChainRulesCore = "2"
 Compat = "4"
 DocThemeIndigo = "0.1.3"
 Documenter = "1"

--- a/src/tangent_types/abstract_zero.jl
+++ b/src/tangent_types/abstract_zero.jl
@@ -17,7 +17,6 @@ Base.iterate(x::AbstractZero) = (x, nothing)
 Base.iterate(::AbstractZero, ::Any) = nothing
 
 Base.first(x::AbstractZero) = x
-Base.tail(x::AbstractZero) = x
 Base.last(x::AbstractZero) = x
 
 Base.Broadcast.broadcastable(x::AbstractZero) = Ref(x)

--- a/src/tangent_types/structural_tangent.jl
+++ b/src/tangent_types/structural_tangent.jl
@@ -360,16 +360,6 @@ Base.iszero(::Tangent{<:,Tuple{}}) = true
 Base.first(tangent::Tangent{P,T}) where {P,T<:Union{Tuple,NamedTuple}} = first(backing(canonicalize(tangent)))
 Base.last(tangent::Tangent{P,T}) where {P,T<:Union{Tuple,NamedTuple}} = last(backing(canonicalize(tangent)))
 
-Base.tail(t::Tangent{P}) where {P<:Tuple} = Tangent{_tailtype(P)}(Base.tail(backing(canonicalize(t)))...)
-@generated _tailtype(::Type{P}) where {P<:Tuple} = Tuple{P.parameters[2:end]...}
-Base.tail(t::Tangent{<:Tuple{Any}}) = NoTangent()
-Base.tail(t::Tangent{<:Tuple{}}) = NoTangent()
-
-Base.tail(t::Tangent{P}) where {P<:NamedTuple} = Tangent{_tailtype(P)}(; Base.tail(backing(canonicalize(t)))...)
-_tailtype(::Type{NamedTuple{S,P}}) where {S,P} = NamedTuple{Base.tail(S), _tailtype(P)}
-Base.tail(t::Tangent{<:NamedTuple{<:Any, <:Tuple{Any}}}) = NoTangent()
-Base.tail(t::Tangent{<:NamedTuple{<:Any, <:Tuple{}}}) = NoTangent()
-
 function Base.getindex(tangent::Tangent{P,T}, idx::Int) where {P,T<:Union{Tuple,NamedTuple}}
     back = backing(canonicalize(tangent))
     return unthunk(getfield(back, idx))

--- a/src/tangent_types/thunks.jl
+++ b/src/tangent_types/thunks.jl
@@ -30,7 +30,6 @@ end
 
 Base.first(x::AbstractThunk) = first(unthunk(x))
 Base.last(x::AbstractThunk) = last(unthunk(x))
-Base.tail(x::AbstractThunk) = Base.tail(unthunk(x))
 
 Base.:(==)(a::AbstractThunk, b::AbstractThunk) = unthunk(a) == unthunk(b)
 

--- a/test/tangent_types/abstract_zero.jl
+++ b/test/tangent_types/abstract_zero.jl
@@ -100,7 +100,6 @@
         
         @test first(z) === z
         @test last(z) === z
-        @test Base.tail(z) === z
     end
 
     @testset "NoTangent" begin

--- a/test/tangent_types/structural_tangent.jl
+++ b/test/tangent_types/structural_tangent.jl
@@ -84,15 +84,11 @@ end
             @test getindex(Tangent{Tuple{Float64}}(@thunk 2.0^2), 1) == 4.0
             @test getproperty(Tangent{Tuple{Float64}}(2.0), 1) == 2.0
             @test getproperty(Tangent{Tuple{Float64}}(@thunk 2.0^2), 1) == 4.0
-            @test NoTangent() === @inferred Base.tail(tang1)
-            @test NoTangent() === @inferred Base.tail(Tangent{Tuple{}}())
             
             tang3 = Tangent{Tuple{Float64, String, Vector{Float64}}}(1.0, NoTangent(), @thunk [3.0] .+ 4)
             @test @inferred(first(tang3)) === tang3[1] === 1.0
             @test @inferred(last(tang3)) isa Thunk
             @test unthunk(last(tang3)) == [7.0]
-            @test Tuple(@inferred Base.tail(tang3))[1] === NoTangent()
-            @test Tuple(Base.tail(tang3))[end] isa Thunk
 
             NT = NamedTuple{(:a, :b),Tuple{Float64,Float64}}
             @test getindex(Tangent{NT}(; a=(@thunk 2.0^2)), :a) == 4.0
@@ -109,10 +105,6 @@ end
             @test unthunk(first(Tangent{NT}(; a=(@thunk 2.0^2)))) == 4.0
             @test last(Tangent{NT}(; a=(@thunk 2.0^2))) isa ZeroTangent
             
-            ntang1 = @inferred Base.tail(Tangent{NT}(; b=(@thunk 2.0^2)))
-            @test ntang1 isa Tangent{<:NamedTuple{(:b,)}}
-            @test NoTangent() === @inferred Base.tail(ntang1)
-
             # TODO: uncomment this once https://github.com/JuliaLang/julia/issues/35516
             # if VERSION >= v"1.8-"
             #     @test haskey(Tangent{Tuple{Float64}}(2.0), 1) == true

--- a/test/tangent_types/thunks.jl
+++ b/test/tangent_types/thunks.jl
@@ -17,11 +17,9 @@
         @test nothing === iterate(@thunk ()) == iterate(())
     end
     
-    @testset "first, last, tail" begin
+    @testset "first, last" begin
         @test first(@thunk (1,2,3) .+ 4) === 5
         @test last(@thunk (1,2,3) .+ 4) === 7
-        @test Base.tail(@thunk (1,2,3) .+ 4) === (6, 7)
-        @test Base.tail(@thunk NoTangent() * 5) === NoTangent()
     end
 
     @testset "show" begin


### PR DESCRIPTION
This causes invalidations and should not be needed anymore by ChainRules.jl since the rule that uses it: https://github.com/JuliaDiff/ChainRulesCore.jl/issues/576#issuecomment-1243943279
Was deleted in https://github.com/JuliaDiff/ChainRules.jl/pull/680.

I ran this on the ChainRules.jl tests and saw a ton of failures locally (also seen in CI), but none that seem related to this change. Disclaimer: I have almost no understanding of this kind of thing :see_no_evil: 

Fixes #576.

Fixes these invalidations seen in CurveFit.jl:
```julia
 inserting tail(t::ChainRulesCore.Tangent{<:NamedTuple{<:Any, <:Tuple{}}}) @ ChainRulesCore ~/.julia/packages/ChainRulesCore/Vsbj9/src/tangent_types/structural_tangent.jl:378 invalidated:                                                                                                                                    
   mt_backedges:  1: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{Int64}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                                   
                  2: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Int64}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                                   
                  3: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Int64}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                                      
                  4: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_interleave(::NamedTuple, ::Any, ::Tuple{Bool, Vararg{Any}}) (0 children)                                                                                                                                 
                  5: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_interleave(::Any, ::Any, ::Any) (0 children)                                                                                                                                                             
                  6: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{NTuple{4, Symbol}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                              
                  7: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{NTuple{4, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                              
                  8: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (0 children)                                                                                                                                       
                  9: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{NTuple{4, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                                 
                 10: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{Symbol}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                                  
                 11: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                                  
                 12: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (0 children)                                                                                                                                       
                 13: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                                     
                 14: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{Symbol, Symbol, Symbol}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                  
                 15: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol, Symbol, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                  
                 16: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (0 children)                                                                                                                                       
                 17: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol, Symbol, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                     
                 18: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{Symbol, Symbol}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                          
                 19: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                          
                 20: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (0 children)                                                                                                                                       
                 21: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Symbol, Symbol}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                             
                 22: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{Int64, Int64}, Vararg{Any}}, ::Any) (0 children)                                                                                                                                            
                 23: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Int64, Int64}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (0 children)                                                                                            
                 24: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (0 children)                                                                                                                                       
                 25: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple{Tuple{Int64, Int64}, Vararg{Any}}, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Bool) (0 children)                                                                                               
                 26: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Tuple{}, Vararg{Tuple{}}}, ::Any) (0 children)                                                                                                                                                    
                 27: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::Base.LogicalIndex, ::Any) (0 children)                                                                                                                                                                                     
                 28: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Float64}, ::Any) (0 children)                                                                                                                                                                                
                 29: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{String}, ::Any) (1 children)                                                                                                                                                                                 
                 30: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_interleave(::NamedTuple, ::Any, ::Any) (1 children)                                                                                                                                                      
                 31: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_interleave(::Any, ::Any, ::NamedTuple) (1 children)                                                                                                                                                      
                 32: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::Base.Iterators.Enumerate{Vector{Any}}, ::Any) (2 children)                                                                                                                                                                 
                 33: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Compiler.MethodMatchInfo}, ::Any) (4 children)                                                                                                                                                               
                 34: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Compiler.ApplyCallInfo}, ::Any) (4 children)                                                                                                                                                                 
                 35: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Union{Nothing, Compiler.ConstResult}}, ::Any) (4 children)                                                                                                                                                   
                 36: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Union{Nothing, Compiler.AbstractIterationInfo}}, ::Any) (4 children)                                                                                                                                         
                 37: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Compiler.CallMeta}, ::Any) (4 children)                                                                                                                                                                      
                 38: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Compiler.NewPhiCNode2}, ::Any) (4 children)                                                                                                                                                                  
                 39: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Tuple{LineNumberNode, Expr}}, ::Any) (4 children)                                                                                                                                                            
                 40: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple{Vararg{Tuple{}}}, ::Any) (4 children)                                                                                                                                                             
                 41: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::Base.Iterators.Enumerate, ::Any) (5 children)                                                                                              
                 42: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_interleave(::NamedTuple, ::NamedTuple, ::Any) (5 children)                                                               
                 43: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::NamedTuple, ::Any, ::Tuple{Bool, Vararg{Any}}, ::Bool) (5 children)                                               
                 44: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::NamedTuple, ::Any, ::Tuple{Any, Vararg{Any}}, ::Bool) (5 children)                                                
                 45: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Broadcast.check_broadcast_shape(::Any, ::Tuple{Base.OneTo{Int64}}) (5 children)                                                                 
                 46: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for axes(::Base.ReinterpretArray{Float64, 1, S, A, true} where A<:Union{SubArray{S, N, A, I, true} where {N, A<:DenseArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, DenseArray{S}}) where S (5 children)
                 47: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::SubArray{T, 1} where T, ::Tuple{Any, Vararg{Any}}) (6 children)                                                                            
                 48: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::NamedTuple, ::Tuple{Bool, Vararg{Any}}, ::Bool) (10 children)                                              
                 49: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for size(::Base.ReinterpretArray{Float64, N, S, A, true} where {N, A<:Union{SubArray{S, N, A, I, true} where {N, A<:DenseArray, I<:Union{Tuple{Vararg{Real}}, Tuple{AbstractUnitRange, Vararg{Any}}}}, DenseArray{S}}}) where S (10 child
ren)                                                                                                                                                                                                                                                                              
                 50: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Tuple, ::Any, ::Tuple{Missing, Vararg{Any}}, ::Missing) (12 children)                                             
                 51: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::SubArray{T, 1} where T, ::Tuple{Any}) (15 children)                                                                                        
                 52: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base._overflowind(::Any, ::Any, ::NTuple{N, Int64} where N) (15 children)                                                                            
                 53: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for iterate(::AbstractRange{Any}, ::Any) (25 children)                                                                                                   
                 54: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_isdone(::Tuple, ::Any) (38 children)                                                                                             
                 55: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base.Iterators._zip_iterate_some(::Any, ::NamedTuple, ::Tuple{Any, Vararg{Any}}, ::Bool) (50 children)                                               
                 56: signature Tuple{typeof(Base.tail), Any} triggered MethodInstance for Base._cshp(::Int64, ::Tuple{Bool}, ::Tuple{Int64}, ::Any) (66 children)   
```